### PR TITLE
Style fixes on en Zoom page

### DIFF
--- a/en/zoom/index.md
+++ b/en/zoom/index.md
@@ -8,15 +8,15 @@ layout: en
 * <span style="color:blue;">2020/4/2:</span> <a href="zoom/setting_issues">Zoom FAQs on setting issues</a>
 
 <!--
-* The person <font color="green">hosting the meeting</font>(or co-hosting) <font color="green">must</font> <a href="create_account" target="">activate its zoom account</a>.
-* Those<font color="purple">participating of a zoom meeting as guests</font>(i.e., joining a meeting)<font color="purple">do not need</font> a zoom account.
+* The person <font color="green">hosting the meeting</font>(or co-hosting) <font color="green">must</font> <a href="create_account" target="">activate its Zoom account</a>.
+* Those<font color="purple">participating of a Zoom meeting as guests</font>(i.e., joining a meeting)<font color="purple">do not need</font> a Zoom account.
 * Now, there are many cases reporting <font color="red">an error message "user not exist" </font>when trying to activate an account. In this case, check the <a href="https://tinyurl.com/v5pvzb5">troubleshooting assistant </a>and answer the survey at the end. In case you still cannot solve the problem, please contact utelecon-inquiries@googlegroups.com.
 * Any other inquiries: utelecon-inquiries@googlegroups.com.
 -->
 
 ## Introduction
 
-* You can use an unlimited time conference room with a maximum of 500 participants until April 30th, 2020 (extension under consideration) by**University's Google mail (10 digits of common ID number @ g.ecc.u-tokyo.ac.jp, hereinafter referred to as ECCS cloud mail)**   
+* You can use an unlimited time conference room with a maximum of 500 participants until April 30th, 2020 (extension under consideration) by **University's Google mail (10 digits of common ID number @ g.ecc.u-tokyo.ac.jp, hereinafter referred to as ECCS cloud mail)**   
 * This section describes the features and usage flow of the Web conferencing tool in Zoom. In addition, there are sub-pages with specific instructions, so please refer to them as necessary.
 * This page basically describes the use of Zoom on a PC, but you can also use the Zoom application on tablets and smartphones..
 
@@ -28,19 +28,19 @@ layout: en
     * If the distance between the PC and the participant is long, such as when sharing a single PC among multiple people in the same room or when taking a picture of a person speaking in the lecture room, it is recommended to use an external USB camera or high-sensitivity microphone. 
     
 * Organizer
-  1. Install zoom（<a href="install" target="">details</a>）  
-  1. Create an account（<a href="create_account" target="">details</a>）
-  1. Create and share a conference room（<a href="create_room" target="">details</a>）
-  1. Enter the meeting room（<a href="join" target="">details</a>）
+  1. Install Zoom (<a href="install" target="">details</a>)  
+  1. Create an account (<a href="create_account" target="">details</a>)
+  1. Create and share a conference room (<a href="create_room" target="">details</a>)
+  1. Enter the meeting room (<a href="join" target="">details</a>)
   1. Start the meeting
     * <a href="how_to_use" target="">Organizer・Participant common guidelines</a>
 	* <a href="how_to_use_host" target="">Organizer specific guidelines</a>
   
 * Participant
-  1. Install zoom（<a href="install" target="">details</a>）  
+  1. Install Zoom (<a href="install" target="">details</a>)  
   1. Obtain meeting room information (URL, etc.) from the organizer using e-mail etc.
-  1. Enter the meeting room（<a href="join" target="">details</a>）
-  1. Start the meeting（<a href="how_to_use" target="">specific guidelines on use</a>）
+  1. Enter the meeting room (<a href="join" target="">details</a>)
+  1. Start the meeting (<a href="how_to_use" target="">specific guidelines on use</a>)
 
 ## How to use in class
 
@@ -50,30 +50,30 @@ layout: en
 * How to use in class (Student Edition)
   * <a href="">How to raise your hand (under construction)</a>
   <br>
-* How to use in class（Teacher Edition）
+* How to use in class (Teacher Edition)
   * <a href="how_to_use_in_classroom_faculty_members#schedule">Schedule lessons</a>
-  * <a href="" target="">［Screen sharing］Presenting materials（under construction）</a>
-  * <a href="" target="">［Chat］Accepting questions（under construction）</a>
-  * <a href="" target="">［Poll］Ask questions to students（under construction）</a>
-  * <a href="" target="">［Breakout］Encourage group work（under construction）</a>
-  * <a href="" target="">［Recording］Record classes（under construction）</a>
+  * <a href="" target="">[Screen sharing] Presenting materials (under construction)</a>
+  * <a href="" target="">[Chat] Accepting questions (under construction)</a>
+  * <a href="" target="">[Poll] Ask questions to students (under construction)</a>
+  * <a href="" target="">[Breakout] Encourage group work (under construction)</a>
+  * <a href="" target="">[Recording] Record classes (under construction)</a>
 
 
 ## Reference information
-[Q&A](qa)  
+[Q&A](qa) (Japanese version only)
 
 
 ## Subpage list
 * <a href="install" target="">How to install</a>  
-* <a href="create_account" target="">How to create an account（for organizers）</a>  
-* <a href="create_room" target="">How to create a meeting room（for organizers）</a>  
+* <a href="create_account" target="">How to create an account (for organizers)</a>  
+* <a href="create_room" target="">How to create a meeting room (for organizers)</a>  
 * <a href="join" target="">How to enter a meeting room</a>  
 * How to use Zoom
   * <a href="how_to_use" target="">Organizer・Participant common guidelines</a>  
   * <a href="how_to_use_host" target="">Organizer specific guidelines</a>  
 * How to use in class  
-  * <a href="classroom_screen_sharing" target="">［Screen sharing］Presenting materials（under construction）</a>  
-  * <a href="classroom_chat" target="">［Chat］Accepting questions（under construction）</a>  
-  * <a href="classroom_poll" target="">［Poll］Ask questions to students（under construction）</a>  
-  * <a href="classroom_breakout" target="">［Breakout］Encourage group work（under construction）</a>  
-  * <a href="classroom_record" target="">［Recording］Record classes（under construction）</a>  
+  * <a href="classroom_screen_sharing" target="">[Screen sharing] Presenting materials (under construction)</a>  
+  * <a href="classroom_chat" target="">[Chat] Accepting questions (under construction)</a>  
+  * <a href="classroom_poll" target="">[Poll] Ask questions to students (under construction)</a>  
+  * <a href="classroom_breakout" target="">[Breakout] Encourage group work (under construction)</a>  
+  * <a href="classroom_record" target="">[Recording] Record classes (under construction)</a>  


### PR DESCRIPTION
- replace full-width characters with half-width ones
- insert a space between words
- use capitalized representation for all occurrences of Zoom as it's a proper noun
- add a note to a link that is linked to not-yet-translated page