### PR TITLE
fix links to non-existent pages

### DIFF
--- a/webex/join_meeting_vc.markdown
+++ b/webex/join_meeting_vc.markdown
@@ -15,6 +15,6 @@ title: Webex 会議への参加 （テレビ会議システム）
 
 <br>
 <br>
-<a href="index" target="_blank">WebExの使い方ページに戻る</a>
-<a href="do_meeting_vc" target="_blank">会議でできること（開催者・参加者）をみる</a>
+<a href="index" target="_blank">WebExの使い方ページに戻る</a>，
+<a href="do_meeting_vc" target="_blank">会議でできること（開催者・参加者）をみる</a>，
 <a href="do_meeting_vc_host" target="_blank">会議でできること（開催者）をみる</a>

--- a/webex/join_meeting_vc.markdown
+++ b/webex/join_meeting_vc.markdown
@@ -16,5 +16,5 @@ title: Webex 会議への参加 （テレビ会議システム）
 <br>
 <br>
 <a href="index" target="_blank">WebExの使い方ページに戻る</a>
-<a href="meeting_participant" target="_blank">会議でできること（参加者）をみる</a>
-<a href="meeting_owner" target="_blank">会議でできること（開催者）をみる</a>
+<a href="do_meeting_vc" target="_blank">会議でできること（開催者・参加者）をみる</a>
+<a href="do_meeting_vc_host" target="_blank">会議でできること（開催者）をみる</a>


### PR DESCRIPTION
/meeting_participant、/meeting_ownerが存在しないので、ひとまず通常のWebex Meetingsの案内に飛ばしておきます。