### PR TITLE
sso化に伴うzoomのログイン方法の変化について明記した

### DIFF
--- a/en/zoom/index.md
+++ b/en/zoom/index.md
@@ -14,7 +14,8 @@ layout: en
 
 ## Introduction
 
-* You can use an unlimited time conference room with a maximum of 500 participants until April 30th, 2020 (extension under consideration) by **University's Google mail (10 digits of common ID number @ g.ecc.u-tokyo.ac.jp, hereinafter referred to as ECCS cloud mail)**   
+* You can use an unlimited time conference room with a maximum of 500 participants until April 30th, 2020 (extension under consideration) by University's Google mail (10 digits of common ID number @ g.ecc.u-tokyo.ac.jp, hereinafter referred to as ECCS cloud mail)
+* **The sign-in methods for zoom have changed. Please refer to [Sign-in Methods for Zoom](/en/zoom/zoom_signin.html)**
 * This section describes the features and usage flow of the Web conferencing tool in Zoom. In addition, there are sub-pages with specific instructions, so please refer to them as necessary.
 * This page basically describes the use of Zoom on a PC, but you can also use the Zoom application on tablets and smartphones..
 


### PR DESCRIPTION
sso化の際に，日本語版のページを大幅に変更し，utlecon内のzoomに関連するリンクを集めたページにしました．英語版を作成するにあたっては，とりあえず，日本語版でリンクしているページの英訳を充実させることが先決だと思われるため，本ページ（英語版）の改修作業は保留しています．しかし，zoomのログインの方法は重要と思われるため，今回の変更で，応急処置的に新しいサインイン方法を紹介することにしました．