### PR TITLE
英語ページのフロントマター`lang: en`不要化

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,17 @@
 google_analytics: UA-160716658-1
 plugins:
-    - jekyll-redirect-from
+  - jekyll-redirect-from
 sass:
-    sass_dir: _sass
+  sass_dir: _sass
 lang: ja
 title: utelecon
 repository: utelecon/utelecon.github.io
 defaults:
+  -
+    scope:
+      path: ""
+    values:
+      lang: ja
   -
     scope:
       path: en

--- a/_config.yml
+++ b/_config.yml
@@ -6,3 +6,9 @@ sass:
 lang: ja
 title: utelecon
 repository: utelecon/utelecon.github.io
+defaults:
+  -
+    scope:
+      path: en
+    values:
+      lang: en

--- a/_includes/layouts/common.html
+++ b/_includes/layouts/common.html
@@ -1,5 +1,5 @@
-{% include layouts/lang.html %}<!DOCTYPE html>
-<html lang="{{ lang }}"{% if lang == "en" %} class="en"{% endif %}>
+<!DOCTYPE html>
+<html lang="{{ page.lang }}"{% if page.lang == "en" %} class="en"{% endif %}>
   <head>
 
     {% if site.google_analytics %}

--- a/_includes/layouts/footer.html
+++ b/_includes/layouts/footer.html
@@ -1,5 +1,3 @@
-{% include layouts/lang.html %}
-
 {% unless page.slug == "support" %}
 <div class="footer-wrap">
   <a class="footer-link wide-only" href="javascript: scroll({top: 0, behavior: 'smooth'});">
@@ -10,7 +8,7 @@
     <div class="footer-icon"><span class="material-icon">feedback</span></div>
     <div class="footer-description">フィードバック</div>
   </a>
-  <a class="footer-link" href="{% if lang == "en" %}/en{% endif %}/support/" target="_blank">
+  <a class="footer-link" href="{% if page.lang == "en" %}/en{% endif %}/support/" target="_blank">
     <div class="footer-icon"><span class="material-icon">contact_support</span></div>
     <div class="footer-description">サポート窓口</div>
   </a>
@@ -20,8 +18,8 @@
 <footer>
   <div class="footer__logo">
     <a href="https://www.u-tokyo.ac.jp/" target="_blank" rel="noopener"><img class="footer__logo__utokyo" src="/assets/images/UTlogo.png" alt="東京大学 the University of Tokyo"></a>
-    <a class="footer__logo__utelecon" href="/{% if lang == "en" %}en/{% endif %}">{%
-      if lang == "en"
+    <a class="footer__logo__utelecon" href="/{% if page.lang == "en" %}en/{% endif %}">{%
+      if page.lang == "en"
         %}utelecon: Online Class / Web Conference Portal Site{%
       else
         %}utelecon: オンライン授業・Web会議ポータルサイト{%
@@ -30,7 +28,7 @@
   </div>
   <nav class="footer__nav">
     <ul>
-      {% for item in site.data.nav[lang] %}
+      {% for item in site.data.nav[page.lang] %}
         <li>
           <div>{{ item.name }}</div>
           <ul class="">

--- a/_includes/layouts/header.html
+++ b/_includes/layouts/header.html
@@ -1,4 +1,3 @@
-{% include layouts/lang.html %}
 <header id="header" class="header">
   <div class="header__primary">
     <button id="header__hamburger-button" class="header__hamburger-button">
@@ -6,10 +5,10 @@
       <span class="header__hamburger-button__text">Menu</span>
     </button>
     <{% if include.is_top %}h1{% else %}div{% endif %} class="header__title">
-      <a class="header__title__link" href="/{% if lang == "en" %}en/{% endif %}">
+      <a class="header__title__link" href="/{% if page.lang == "en" %}en/{% endif %}">
         <span class="header__title__main">utelecon</span>
         <span class="header__title__sub">{%
-          if lang == "en"
+          if page.lang == "en"
             %}Online Class / Web Conference Portal Site @ the University of Tokyo{%
           else
             %}オンライン授業・Web会議ポータルサイト @ 東京大学{%
@@ -22,8 +21,8 @@
     <div class="header__links">
       <div class="gcse-search"></div>
       <div>
-        <a href="/{% if lang == "en" %}en/{% endif %}">TOP</a> | {%
-          if lang == "en"
+        <a href="/{% if page.lang == "en" %}en/{% endif %}">TOP</a> | {%
+          if page.lang == "en"
             %}<a href="{{ page.url | replace: '.html', '' | replace_first: 'en/', '' }}">日本語</a>{%
           else
             %}<a href="/about/">About</a> | <a href="/en{{ page.url | replace: '.html', '' }}">English</a>{%
@@ -33,7 +32,7 @@
     </div>
     <nav class="header__nav">
       <ul>
-        {% for item in site.data.nav[lang] %}
+        {% for item in site.data.nav[page.lang] %}
           <li>
             <div class="header_nav_text">{{ item.name }}</div>
             <ul>

--- a/_includes/layouts/lang.html
+++ b/_includes/layouts/lang.html
@@ -1,1 +1,0 @@
-{% assign lang = page.lang | default: site.lang | default: "ja" %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,4 +1,3 @@
-{% include layouts/lang.html %}
 {% capture content %}
 {% include layouts/header.html %}
 
@@ -18,7 +17,7 @@
   {% assign toc = toc | rstrip %}
   {% if toc != "" and page.toc != false %}
     <section class="main__toc">
-      <h2>{% if lang == "en" %}Table of Contents{% else %}目次{% endif %}</h2>
+      <h2>{% if page.lang == "en" %}Table of Contents{% else %}目次{% endif %}</h2>
 {{ toc }}
     </section>
   {% endif %}

--- a/en/articles/google-form/index.md
+++ b/en/articles/google-form/index.md
@@ -1,6 +1,5 @@
 ---
 title: Conducting Quizzes and Surveys with Google Forms
-lang: en
 ---
 
 ## Highlights of This Article

--- a/en/change2021s/index.md
+++ b/en/change2021s/index.md
@@ -1,6 +1,5 @@
 ---
 title: System Change for Spring 2021 
-lang: en
 ---
 
 <div class="important-box">UTokyo Account login service will begin on March 15 for Zoom and March 13 for Webex. Previous login methods will no longer be available.</div>

--- a/en/change2021s/webex.md
+++ b/en/change2021s/webex.md
@@ -1,6 +1,5 @@
 ---
 title: Details on Webex System Change for Spring 2021
-lang: en
 ---
 
 To facilitate online teaching and simplify technical operation, UTokyo ICT systems are updated. This page concerns Webex system change only. For information about other ICT systems, see “**[System Change for Spring 2021](/en/change2021s/)**”.

--- a/en/change2021s/zoom.md
+++ b/en/change2021s/zoom.md
@@ -1,6 +1,5 @@
 ---
 title: Details on Zoom System Change for Spring 2021
-lang: en
 ---
 
 To facilitate online teaching and simplify technical operation, UTokyo ICT systems changes are in progress. This page is about the changes in the use of Zoom. For information about other ICT systems, see “**[System Change for Spring 2021](/en/change2021s/)**”.

--- a/en/compare.md
+++ b/en/compare.md
@@ -1,6 +1,5 @@
 ---
 title: Comparison between systems
-lang: en
 ---
 
 |              Aspects               |                          Google Hangouts Meet                   |  Zoom  |  WebEx  |  

--- a/en/eccs_cloud_email.md
+++ b/en/eccs_cloud_email.md
@@ -1,6 +1,5 @@
 ---
 title: ECCS Cloud Email (Google Workspace)
-lang: en
 ---
 
 ## What is ECCS Cloud Email?

--- a/en/events/2020-03-13/index.markdown
+++ b/en/events/2020-03-13/index.markdown
@@ -1,6 +1,5 @@
 ---
 title: 2020/03/13 Briefing on How to host Video Conferences when aiming for Online Classes
-lang: en
 ---
 
 

--- a/en/events/2020-03-19/index.md
+++ b/en/events/2020-03-19/index.md
@@ -1,6 +1,5 @@
 ---
 title: 2020/03/19 Online course "How to use Zoom for online classes"
-lang: en
 ---
 
 The online course will be held on MArch 19, 2020, from 15pm to 17pm. Please check <a href="https://www.ut-portal.u-tokyo.ac.jp/notice/index.php?q=32134" target="_blank">here（on campus access restricted）</a> for details on details and application.

--- a/en/events/2020-03-19/report.md
+++ b/en/events/2020-03-19/report.md
@@ -1,6 +1,5 @@
 ---
 title: 2020/3/19 Online Course Report
-lang: en
 ---
 
 　An online workshop on  "How to use Zoom in online courses in mind" was conducted on March 19, 2020, from 15:00 to 17:00. 

--- a/en/events/2020-03-26/index.md
+++ b/en/events/2020-03-26/index.md
@@ -1,6 +1,5 @@
 ---
 title: 2020/03/26 Briefing - How to notify students of online classes
-lang: en
 ---
 
 **Date:** 3/26(Thu) 15:30-17:00 

--- a/en/events/2020-03-27/index.md
+++ b/en/events/2020-03-27/index.md
@@ -1,6 +1,5 @@
 ---
 title: 2020/03/27 Online Course "How to Prepare (Asynchronous) On-Demand Online Classes Using Videos and Texts" and "Online Class Consultation Meetings Specializing in Language Learning"
-lang: en
 ---
 
 ## "How to Prepare (Asynchronous) On-Demand Online Classes Using Videos and Texts"

--- a/en/events/2020-04-16/index.md
+++ b/en/events/2020-04-16/index.md
@@ -1,6 +1,5 @@
 ---
 title: 2020/04/16 Briefing session - Two weeks after the start of S semester
-lang: en
 ---
 
 * **Date:** 4/16 (Thursday) 17: 00-18: 30

--- a/en/events/2020-05-08/index.md
+++ b/en/events/2020-05-08/index.md
@@ -1,6 +1,5 @@
 ---
 title: "2020/05/08 Briefing session: Using copyrighted materials in online classes"
-lang: en
 ---
 
 * **Date and time:** Friday, May 8 17: 00-18: 30

--- a/en/events/2020-05-20/index.md
+++ b/en/events/2020-05-20/index.md
@@ -1,6 +1,5 @@
 ---
 title: "2020/05/20 Training: Class Supporters"
-lang: en
 ---
 
 * **Time:** 5/20(Wed) 15:00-17:00(a recording of the training will be released at a later date, for those who cannot attend the training on this day)

--- a/en/events/2020-luncheon/index.md
+++ b/en/events/2020-luncheon/index.md
@@ -1,6 +1,5 @@
 ---
 title: Lunch time information exchange meeting
-lang: en
 ---
 
 We have started meetings to exchange information at lunch time.

--- a/en/events/index.md
+++ b/en/events/index.md
@@ -1,6 +1,5 @@
 ---
 title: Orientations / Seminars
-lang: en
 ---
 
 * 2021/09/15 [Briefing session: Online Classes for 2021 A semester - Educational ICT and Online / Hybrid Classes (Japanese Only)](/events/2021-09-15/)

--- a/en/faculty_members/how_to_teach_online_handwriting.md
+++ b/en/faculty_members/how_to_teach_online_handwriting.md
@@ -1,6 +1,5 @@
 ---
 title: Online Handwriting
-lang: en
 ---
 
 Here, we will introduce how to teach using online handwriting.

--- a/en/faculty_members/index.md
+++ b/en/faculty_members/index.md
@@ -1,6 +1,5 @@
 ---
 title: Preparing for online classes at the University of Tokyo (for faculty members)
-lang: en
 slug: faculty_members # 手順を外部ファイルからincludeするときに使う
 ---
 

--- a/en/faculty_members/index_2020_a.md
+++ b/en/faculty_members/index_2020_a.md
@@ -1,6 +1,5 @@
 ---
 title: Online teaching for instructors (2020 A Semester)
-lang: en
 ---
 
 ## Introduction  

--- a/en/faculty_members/index_2020_s.md
+++ b/en/faculty_members/index_2020_s.md
@@ -1,6 +1,5 @@
 ---
 title: Online teaching for instructors
-lang: en
 ---
 Last update: 2020/4/2
 

--- a/en/faculty_members/let_students_know_your_url.md
+++ b/en/faculty_members/let_students_know_your_url.md
@@ -1,6 +1,5 @@
 ---
 title: How to let your students know your online class URL
-lang: en
 ---
 
 How to let your students know your online class URL -- Ground rules to safely meet instructors and students

--- a/en/faculty_members/url.md
+++ b/en/faculty_members/url.md
@@ -1,6 +1,5 @@
 ---
 title: How to Announce Online Class URL  (for Faculty Members)
-lang: en
 ---
 
 This page explains how instructors announce the online class URL (the URL of web conference rooms such as Zoom) to students. 

--- a/en/faculty_members/zoom_access_control.md
+++ b/en/faculty_members/zoom_access_control.md
@@ -1,6 +1,5 @@
 ---
 title: Restricting Access to Zoom Meeting Rooms for Online Classes
-lang: en
 ---
 
 This page introduces methods to prevent unintended participants (so-called "trolls" or Zoom Bombing) from joining Zoom meeting rooms used for online classes.

--- a/en/faq/index.md
+++ b/en/faq/index.md
@@ -1,6 +1,5 @@
 ---
 title: FAQ
-lang: en
 ---
 
 If this FAQ cannot solve your problem, please contact the [Technical Support Desk](/en/support/).

--- a/en/forms/et.md
+++ b/en/forms/et.md
@@ -1,6 +1,5 @@
 ---
 title: Form for students facing trouble when Joining Classes
-lang: en
 ---
 
 Please report here in case if you have tried to attend a class but could not enter it.  We will contact the faculty member of the department / school.

--- a/en/forms/takecarestudents.md
+++ b/en/forms/takecarestudents.md
@@ -1,6 +1,5 @@
 ---
 title: Student Care・Department/School Registration Form
-lang: en
 ---
 
 The following inquiries are increasing after the classes start.

--- a/en/forums/index.md
+++ b/en/forums/index.md
@@ -1,6 +1,5 @@
 ---
 title: QA Forum and Mailing List for Announcements
-lang: en
 ---
 
 Introduction

--- a/en/improvement/index.md
+++ b/en/improvement/index.md
@@ -1,6 +1,5 @@
 ---
 title: Improving Online Classes
-lang: en
 ---
 
 ## Introduction

--- a/en/index.html
+++ b/en/index.html
@@ -1,6 +1,5 @@
 ---
 title: Online Class / Web Conference Portal Site @ the University of Tokyo
-lang: en
 layout: common
 ---
 

--- a/en/itc_lms.md
+++ b/en/itc_lms.md
@@ -1,6 +1,5 @@
 ---
 title: ITC-LMS
-lang: en
 ---
 
 ## What is ITC-LMS

--- a/en/lms_lecturers/assignments.md
+++ b/en/lms_lecturers/assignments.md
@@ -1,6 +1,5 @@
 ---
 title: Prepare assignments
-lang: en
 ---
 
 ## Overview

--- a/en/lms_lecturers/attendances.md
+++ b/en/lms_lecturers/attendances.md
@@ -1,6 +1,5 @@
 ---
 title: Let your students know the code for attendance (TBA)
-lang: en
 ---
 1. After the start time of “Date and time for submission” set in <a href="prepare_attendances" target="">Preparations for taking attendance during class</a>, the "Submit Attendance" button will appear when the student logs in to ITC-LMS and displays the “Course TOP” screen of the course.
 ![出席送信](at1.png)

--- a/en/lms_lecturers/course_materials.md
+++ b/en/lms_lecturers/course_materials.md
@@ -1,6 +1,5 @@
 ---
 title: Upload Materials
-lang: en
 ---
 
 ## Summary

--- a/en/lms_lecturers/course_settings.md
+++ b/en/lms_lecturers/course_settings.md
@@ -1,6 +1,5 @@
 ---
 title: Set the course
-lang: en
 ---
 In ITC-LMS, lectures offered in terms and semesters are called "Courses". First, set up the course according to your subject.
 

--- a/en/lms_lecturers/index.md
+++ b/en/lms_lecturers/index.md
@@ -1,6 +1,5 @@
 ---
 title: How to use the Learning Management System ITC-LMS（for instructors）
-lang: en
 ---
 
 ## Introduction

--- a/en/lms_lecturers/information.md
+++ b/en/lms_lecturers/information.md
@@ -1,6 +1,5 @@
 ---
 title: Set the notifications
-lang: en
 ---
 
 When you log into ITC-LMS, you can see students’ activity (e.g. message to teachers,  or  whether a student submits a homework or not) as a “Notification".  In addition, you can accept the notification by email or LINE application.  Here we introduce how to set the information.

--- a/en/lms_lecturers/login.md
+++ b/en/lms_lecturers/login.md
@@ -1,6 +1,5 @@
 ---
 title: How to log in ITC-LMS
-lang: en
 ---
 
 Here we are going to introduce you how to log into ICT-LMS.  The login method is the same for teachers and students.

--- a/en/lms_lecturers/prepare_attendances.md
+++ b/en/lms_lecturers/prepare_attendances.md
@@ -1,6 +1,5 @@
 ---
 title: Prepare for confirming attendance in classes
-lang: en
 ---
 In online classes, you can set “check the attendance” on ITC-LMS. You can use as follows:
 

--- a/en/lms_lecturers/prepare_quizzes.md
+++ b/en/lms_lecturers/prepare_quizzes.md
@@ -1,6 +1,5 @@
 ---
 title: Preparing quizzes
-lang: en
 ---
 
 ## Overview

--- a/en/lms_lecturers/timetable.md
+++ b/en/lms_lecturers/timetable.md
@@ -1,6 +1,5 @@
 ---
 title: Timetable
-lang: en
 ---
 
 When you log in, the following time table will be displayed.

--- a/en/lms_lecturers/view_attendances.md
+++ b/en/lms_lecturers/view_attendances.md
@@ -1,6 +1,5 @@
 ---
 title: Confirm attendance
-lang: en
 ---
 After asking the student to press the "Send Attendance" button and to enter a one-time password, follow the instructions below to check their status.
 

--- a/en/meet/index.markdown
+++ b/en/meet/index.markdown
@@ -1,6 +1,5 @@
 ---
 title: Google Hangouts Meet  
-lang: en
 ---
 
 ## Introduction

--- a/en/notice/guideline.md
+++ b/en/notice/guideline.md
@@ -1,6 +1,5 @@
 ---
 title: The tools usage guideline for online class since S semester 2021
-lang: en
 --- 
 This is english translation of Japanese document.
 

--- a/en/notice/index.md
+++ b/en/notice/index.md
@@ -1,6 +1,5 @@
 ---
 title: Notice
-lang: en
 ---
 
 {% comment %} To add notice here, edit `_data/notice/en.yml` {% endcomment %}

--- a/en/notice/zoom-address-new.md
+++ b/en/notice/zoom-address-new.md
@@ -1,6 +1,5 @@
 ---
 title:  Using Zoom with Non-UTokyo Account Sign-in
-lang: en
 ---
 <!-- ↑”Signing in to Zoom”の記事内で、本記事を参照している箇所あり。本記事のタイトルを変更する場合は、そちらにも変更を反映することが必要。-->
 

--- a/en/oc/index.md
+++ b/en/oc/index.md
@@ -1,6 +1,5 @@
 ---
 title: Preparing for online classes at the University of Tokyo (for new students enrolled in AY2021)
-lang: en
 slug: oc # 手順を外部ファイルからincludeするときに使う
 ---
 

--- a/en/oc/index_2020_a.md
+++ b/en/oc/index_2020_a.md
@@ -1,6 +1,5 @@
 ---
 title: Preparing for online classes for new and currently enrolled students (2020 A Semester)
-lang: en
 ---
 
 Introduction

--- a/en/oc/index_2020_s.md
+++ b/en/oc/index_2020_s.md
@@ -1,6 +1,5 @@
 ---
 title: Preparing for online classes for new and currently enrolled students
-lang: en
 ---
 
 Note

--- a/en/oc/join.md
+++ b/en/oc/join.md
@@ -1,6 +1,5 @@
 --- 
 title: How to join a online class
-lang: en
 ---
 
 This page explains how to join a “simultaneous interactive” online class conducted via web conference systems such as Zoom or Webex. 

--- a/en/oc/url.md
+++ b/en/oc/url.md
@@ -1,6 +1,5 @@
 ---
 title: How to Obtain the Online Class URL (for Students)
-lang: en
 ---
  
 A specific URL is essential to participate in a “simultaneous interactive” online class. This page explains how to obtain the class URL. 

--- a/en/sitemap/index.md
+++ b/en/sitemap/index.md
@@ -1,6 +1,5 @@
 ---
 title: Sitemap
-lang: en
 sitemap: false
 ---
 

--- a/en/support/index.md
+++ b/en/support/index.md
@@ -1,6 +1,5 @@
 ---
 title: Technical Support Desk
-lang: en
 slug: support
 ---
 

--- a/en/supporters/class.md
+++ b/en/supporters/class.md
@@ -1,6 +1,5 @@
 ---
 title: Online Class Supporters Program
-lang: en
 ---
 
 What is a Class Supporter

--- a/en/supporters/class_a.md
+++ b/en/supporters/class_a.md
@@ -1,6 +1,5 @@
 ---
 title: Online Class Supporters Program (2020 A Semester)
-lang: en
 ---
 
 Notifications

--- a/en/utas.md
+++ b/en/utas.md
@@ -1,6 +1,5 @@
 ---
 title: UTAS
-lang: en
 ---
 
 ## What is UTAS?

--- a/en/utokyo_account/mfa/index.md
+++ b/en/utokyo_account/mfa/index.md
@@ -1,6 +1,5 @@
 ---
 title: Using Multi-Factor Authentication for UTokyo Accounts
-lang: en
 css: [mfa]
 ---
 

--- a/en/webex/create_events.markdown
+++ b/en/webex/create_events.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to Create Webex events
-lang: en
 ---
 
 ## Create an event

--- a/en/webex/create_meeting.markdown
+++ b/en/webex/create_meeting.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to set the meeting room
-lang: en
 ---
 
 ## How to create an Webex Meeting room 

--- a/en/webex/create_training.markdown
+++ b/en/webex/create_training.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to create Webex training
-lang: en
 ---
 
 ## How to Create Webex Training

--- a/en/webex/create_webex_account.markdown
+++ b/en/webex/create_webex_account.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to Log in and Create an UTokyo Webex account
-lang: en
 ---
 
 ## Create a Webex Account	

--- a/en/webex/do_events.markdown
+++ b/en/webex/do_events.markdown
@@ -1,6 +1,5 @@
 ---
 title: What is possible with Webex Events?（for Instructors・Participants)
-lang: en
 ---
 
 ## Roles

--- a/en/webex/do_events_host.markdown
+++ b/en/webex/do_events_host.markdown
@@ -1,6 +1,5 @@
 ---
 title: What is possible with Webex Events?（for Instructors)
-lang: en
 ---
 
 * This section describes the Webex Events functions only available to the host.	

--- a/en/webex/do_meeting.markdown
+++ b/en/webex/do_meeting.markdown
@@ -1,6 +1,5 @@
 ---
 title: What is possible with Webex Meetings?（for Instructors・Participants)
-lang: en
 ---
 
 ## Roles

--- a/en/webex/do_meeting_host.markdown
+++ b/en/webex/do_meeting_host.markdown
@@ -1,6 +1,5 @@
 ---
 title: Webex meeting room 101（for instructors）
-lang: en
 ---
 
 * In this section, we will explain the Webex Meetings functions that are unique to the Host of the meeting.

--- a/en/webex/do_meeting_vc.markdown
+++ b/en/webex/do_meeting_vc.markdown
@@ -1,6 +1,5 @@
 ---
 title: What is possible with Webex Meetings?（Instructors and Participants from TV conference systems）
-lang: en
 ---
 
 * In this section, we will explain what the host / participants of the meeting and the teachers can do in class.

--- a/en/webex/do_training.markdown
+++ b/en/webex/do_training.markdown
@@ -1,6 +1,5 @@
 ---
 title: What is possible with Webex Training?（for Instructors・Participants)
-lang: en
 ---
 
 ## Roles

--- a/en/webex/do_training_host.markdown
+++ b/en/webex/do_training_host.markdown
@@ -1,6 +1,5 @@
 ---
 title: What is possible with Webex Training?（for Instructors)
-lang: en
 ---
 
 * This section describes the Webex Training functions only available to the host.	

--- a/en/webex/index.markdown
+++ b/en/webex/index.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to use Webex
-lang: en
 ---
 
 

--- a/en/webex/join_events.markdown
+++ b/en/webex/join_events.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to Join Events
-lang: en
 ---
 
 ## Attending Events

--- a/en/webex/join_events_vc.markdown
+++ b/en/webex/join_events_vc.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to join Webex Events （TV Conference Systems）
-lang: en
 ---
 
 ## Join a meeting with a video conferencing system

--- a/en/webex/join_meeting.markdown
+++ b/en/webex/join_meeting.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to join Webex Meetings
-lang: en
 ---
 
 ## Join a meeting

--- a/en/webex/join_meeting_vc.markdown
+++ b/en/webex/join_meeting_vc.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to join Webex Meetings （TV conference systems）
-lang: en
 ---
 
 ## How to Participate in the TV Conference Systems

--- a/en/webex/join_training.markdown
+++ b/en/webex/join_training.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to join Webex Training
-lang: en
 ---
 
 ## Join a meeting

--- a/en/webex/open_events.markdown
+++ b/en/webex/open_events.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to start Webex events
-lang: en
 ---
 
 ## Start an event

--- a/en/webex/open_meeting.markdown
+++ b/en/webex/open_meeting.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to start Webex Meetings
-lang: en
 ---
 
 ## How to Begin a Meeting

--- a/en/webex/open_meeting_vc.markdown
+++ b/en/webex/open_meeting_vc.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to start Webex Meetings （TV conference systems）
-lang: en
 ---
 
 ## How to Start the Meeting of TV Conference systems

--- a/en/webex/open_training.markdown
+++ b/en/webex/open_training.markdown
@@ -1,6 +1,5 @@
 ---
 title: How to start Webex Training
-lang: en
 ---
 
 ## Start Webex Training

--- a/en/webex/signin.md
+++ b/en/webex/signin.md
@@ -1,6 +1,5 @@
 ---
 title: Signing in to Webex
-lang: en
 toc: false
 ---
 

--- a/en/zoom/auth.md
+++ b/en/zoom/auth.md
@@ -1,6 +1,5 @@
 ---
 title: Requiring Authentication to Join a Zoom Meeting
-lang: en
 ---
 
 Authentication profiles allow hosts to restrict Zoom meeting participants to users whose email address matches a certain domain. If the option "大学アカウントでサインイン(Sign in with university account)" is selected, participants will be asked to sign in with their UTokyo Zoom account to join the meeting.

--- a/en/zoom/create_account_invitation.md
+++ b/en/zoom/create_account_invitation.md
@@ -1,6 +1,5 @@
 ---
 title: How to Create a University Zoom Account Using Invitation Email
-lang: en
 ---
 
 ## Notice

--- a/en/zoom/create_room.md
+++ b/en/zoom/create_room.md
@@ -1,6 +1,5 @@
 ---
 title: Scheduling a Zoom Meeting (Web Portal)
-lang: en
 ---
 
 ## Scheduling Meetings

--- a/en/zoom/create_room_software.md
+++ b/en/zoom/create_room_software.md
@@ -1,6 +1,5 @@
 ---
 title: Scheduling a Zoom Meeting (Zoom App)
-lang: en
 ---
 This page provides information on how to schedule a Zoom Meeting with the Zoom App. Settings options may be restricted when scheduling a meeting with the Zoom App. On such occasions, read the instructions in “[Scheduling a Zoom Meeting(Web Portal)](create_room)” and schedule your meetings on the Zoom webpage. For information on scheduling regular meetings, see “[How to set up a room with the same URL for all lectures] (how/faculty_members/schedule).”
 

--- a/en/zoom/how/common/host_cohost.md
+++ b/en/zoom/how/common/host_cohost.md
@@ -1,6 +1,5 @@
 ---
 title: Host and Co-host Controls in a Zoom Meeting
-lang: en
 ---
 
 ## What is a Host?

--- a/en/zoom/how/common/sharing_screen.md
+++ b/en/zoom/how/common/sharing_screen.md
@@ -1,6 +1,5 @@
 ---
 title: Screen Sharing
-lang: en
 ---
 
 Zoom's screen sharing enables you to share your screen with others. You can share the screen you are viewing on your PC or mobile device with all participants. If you open a Word or Power Point file on the shared screen, you can make your presentation showing the document to the participants.

--- a/en/zoom/how/faculty_members/attendance.md
+++ b/en/zoom/how/faculty_members/attendance.md
@@ -1,6 +1,5 @@
 ---
 title: (Zoom for Faculty members ) Managing Attendance
-lang: en
 ---
 
 Using the report function of Zoom, you can see a list of participants and their respective join/leave time. You can use it to manage attendance. 

--- a/en/zoom/how/faculty_members/recording_cloud.md
+++ b/en/zoom/how/faculty_members/recording_cloud.md
@@ -1,6 +1,5 @@
 ---
 title: (Zoom for Faculty Members) Cloud Recording
-lang: en
 ---
 
 UTokyo Zoom account (`10-digit Common ID @utac.u-tokyo.ac.jp`) supports cloud recording.

--- a/en/zoom/how/faculty_members/schedule.md
+++ b/en/zoom/how/faculty_members/schedule.md
@@ -1,6 +1,5 @@
 ---
 title: (Zoom for Faculty Members) Scheduling Recurring Zoom Meetings
-lang: en
 ---
 
 By scheduling recurring meetings, you can use a fixed meeting URL with all 13 class occurrences. 

--- a/en/zoom/how_to_use.md
+++ b/en/zoom/how_to_use.md
@@ -1,6 +1,5 @@
 ---
 title: How to use Zoom
-lang: en
 ---
 
 

--- a/en/zoom/how_to_use_host.md
+++ b/en/zoom/how_to_use_host.md
@@ -1,6 +1,5 @@
 ---
 title: How to use Zoom (for organizers)
-lang: en
 ---
 
 

--- a/en/zoom/how_to_use_in_classroom_faculty_members.md
+++ b/en/zoom/how_to_use_in_classroom_faculty_members.md
@@ -1,6 +1,5 @@
 ---
 title: Using Zoom in class（for instructors）
-lang: en
 ---
 
 In this section, we introduce how teachers can use Zoom in classroom through interactive videos.   

--- a/en/zoom/index.md
+++ b/en/zoom/index.md
@@ -1,6 +1,5 @@
 ---
 title: Zoom
-lang: en
 ---
 
 ## Introduction

--- a/en/zoom/install.md
+++ b/en/zoom/install.md
@@ -1,6 +1,5 @@
 ---
 title: How to install Zoom
-lang: en
 ---
 
 This section describes how to install Zoom.  

--- a/en/zoom/join.md
+++ b/en/zoom/join.md
@@ -1,6 +1,5 @@
 ---
 title: How to join a Zoom meeting room
-lang: en
 ---
 
 In this section we explain how to join a meeting room.  

--- a/en/zoom/license.md
+++ b/en/zoom/license.md
@@ -1,6 +1,5 @@
 ---
 title: Zoom License for Large Meetings/Webinars
-lang: en
 ---
 
 ## Overview

--- a/en/zoom/test.md
+++ b/en/zoom/test.md
@@ -1,6 +1,5 @@
 ---
 title: Test
-lang: en
 sitemap: false
 ---
 

--- a/en/zoom/waiting_room.md
+++ b/en/zoom/waiting_room.md
@@ -1,6 +1,5 @@
 ---
 title: Setting up a Zoom Waiting Room
-lang: en
 ---
 
 The Waiting Room feature enables hosts to first place meeting participants in a waiting room and then explicitly allow them to enter the meeting room.

--- a/en/zoom/zoom_signin.md
+++ b/en/zoom/zoom_signin.md
@@ -1,6 +1,5 @@
 ---
 title: Sign-in Methods for Zoom
-lang: en
 toc: false
 ---
 


### PR DESCRIPTION
デフォルトのフロントマターを設定することで，英語ページのフロントマターを不要とし，またjekyll-seo-tagに配慮した．