### PR TITLE
improve footnote expression

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,8 @@
 google_analytics: UA-160716658-1
 plugins:
   - jekyll-redirect-from
+kramdown:
+  footnote_backlink: ↑
 sass:
   sass_dir: _sass
 lang: ja

--- a/_sass/layout/main.scss
+++ b/_sass/layout/main.scss
@@ -83,8 +83,9 @@ main {
     text-align: right;
   }
 
-  .footnotes{
-    border-top: 2px solid gray;
+  .footnotes {
+    padding-top: 0.5em;
+    border-top: 2px solid $gray;
   }
 }
 

--- a/_sass/layout/main.scss
+++ b/_sass/layout/main.scss
@@ -83,6 +83,9 @@ main {
     text-align: right;
   }
 
+  .footnotes{
+    border-top: 2px solid gray;
+  }
 }
 
 .main__toc {


### PR DESCRIPTION
著作権に関連する記事をアップロードするにあたって、kramdownによって生成されるデフォルトのfootnoteが見にくいということが問題になっています。この変更は、footnoteを見やすくすることを目的としています。

## 変更点
- 区切り線を追加しました。
- footnoteの各行末尾「↩」を「↑」に変更しました。この部分は本文中の対応する箇所に移動するリンクになっています。

## スクリーンショット
変更前イメージ
![image](https://user-images.githubusercontent.com/49227365/176128771-da8db2e2-4cca-4089-b8c7-d164921a199b.png)

変更後イメージ
![image](https://user-images.githubusercontent.com/49227365/176396621-b7d1faf6-173d-4648-8484-2c21544227bd.png)