### PR TITLE
create /en/articles/create_share_movie/

### DIFF
--- a/articles/create_share_movie/index.md
+++ b/articles/create_share_movie/index.md
@@ -43,7 +43,7 @@ title: 動画を作成・共有する
 * YouTube
   * YouTube に動画をアップロードしてダウンロードすると多くの動画が効率的に圧縮されるというお手軽な方法です
   * お手軽ではあるのですが，アップロードが必要であるため，動画が大容量でアップロード自体ができない場合は，VLC Player を用いた圧縮がおすすめです
-  * [動画のアップロード（YouTubeヘルプ）](https://support.google.com/youtube/answer/57407?hl=ja&co=GENIE.Platform=Desktop)
+  * [動画のアップロード（YouTubeヘルプ）](https://support.google.com/youtube/answer/57407?hl=ja)
   * [アップロードした動画をダウンロードする（YouTube ヘルプ）](https://support.google.com/youtube/answer/56100?hl=ja)
 * VLC Player
   * VLC Player の主な機能はメディアの再生ですが，実は動画を圧縮可能です

--- a/en/articles/create_share_movie/index.md
+++ b/en/articles/create_share_movie/index.md
@@ -1,0 +1,66 @@
+---
+title: Creating and Sharing Videos
+---
+
+On this page, we explain how to create and share videos.
+
+Please make use of this when making video materials for on-demand classes and the like.
+
+### Filming the Video
+Here we introduce methods for filming a video through Zoom and PowerPoint. We explain the features of each, so please employ them according to your needs or which you are accustomed to using.
+
+* Zoom
+  * The unique feature of Zoom is that you can use its recording function to easily make a video.
+  * It is equipped with a standard noise suppression function for voice, so it can maintain a fixed sound quality, even if you do not pay attention to the microphone.
+  * Reference site: 
+[It's simple to record video on Zoom!  Use this during your meetings (External link)](https://zoom.nissho-ele.co.jp/blog/manual/zoom-recording.html) (in Japanese)
+* PowerPoint
+  * The unique feature of PowerPoint is that, by using the Record Slideshow function, it is possible to record slide by slide, making it easy to upgrade slides and re-record them.
+  * There is no noise suppression function, so we recommend checking the sound recording after.
+  * Reference site: [Making slideshow videos on PowerPoint (External link)](https://www.cii.u-fukui.ac.jp/COVID19/teaching/PowerPoint-movie.pdf) (in Japanese)
+
+### Editing the Video
+Here we introduce software for cutting, inserting captions, and other ways of editing video. We explain the different features of each, so use them according to your needs.
+
+* losslesscut（Mac, Windows, Linux）
+  * The unique feature of losslesscut is that only cutting is possible and the time for writing out a video is extremely short.
+  * There are times when the place cut misses where you want it to go (This is part of the specifications of the software, so if you want to make sure it cuts right where you specify use the software below).
+  * [How to Use (External link)](https://www.aiseesoft.jp/tutorials/how-to-use-losslesscut.html) (in Japanese)
+* iMovie (Mac)
+  * This is video editing software equipped standard on Macs.
+  * It is easy for beginners to use, so if you are not going to do any advanced editing we recommend using this.
+  * [How to Use (External link)](https://www.pasoble.jp/windows/10/douga-hensyuu.html) (in Japanese)
+* Photo (Windows)
+  * This is video editing software equipped standard on Windows (It is called Photo, but you can also edit videos on it).
+  * [How to Use (External link)](https://www.pasoble.jp/windows/10/douga-hensyuu.html) (in Japanese)
+* Adobe Premiere Pro (Mac, Windows)
+  * This is professional specification software.
+  * Use this when you wish to employ advanced editing.
+* Final Cut Pro (Mac)
+  * This is professional specification software.
+  * Use this when you wish to employ advanced editing.
+
+### Compressing the Video
+Here we explain how to compress video using YouTube and VLC Player.
+* YouTube
+  * For many videos, uploading to, then downloading from, YouTube is an efficient, easy method for compression.
+  * It is easy, but because it is necessary to upload first, if the video is too big to upload in the first place, we recommend compressing by VLC Player.
+  * [Upload YouTube videos (YouTube Help)](https://support.google.com/youtube/answer/57407?hl=en)
+  * [Download YouTube videos that you've uploaded (YouTube Help)](https://support.google.com/youtube/answer/56100?hl=en)
+* VLC Player
+  * VLC Player's main function is playing media, but it can actually also compress video.
+  * It is not necessary to upload anything and you can work locally, so there is no need to worry about the amount you are transmitting.
+  * In the Information System Seminar "Creating and Sharing Videos in Work", there is an explanation of how to operate.
+    * [Slide](/events/2020-09-02/slides.pdf) (in Japanese): Explanation on Slide 29.
+    * [Video (Only available within university)](https://drive.google.com/file/d/1BS0DUilel4zikhvHbIR2mMCTZ_vKBry_/view): Demonstration from 1:41:50
+
+### Sharing the Video
+You can release within university by both Google Drive and YouTube.
+* Sharing on Google Drive
+  * You can also set prohibitions on downloading.
+  * **[Concrete Instructions](/faculty_members/how/google/share_video)** (in Japanese)
+* Sharing on YouTube
+  * If you make availability limited to within the university, it is necessary for others to log into YouTube by their ECCS Cloud Mail address.  There are times when this switchover does not go well for people, so some caution on this point is necessary.
+  * **[Restricting YouTube Content to University Members Only](https://www.sodan.ecc.u-tokyo.ac.jp/en/hack/youtube-utokyo-only-en/)**
+
+


### PR DESCRIPTION
「動画を作成・共有する」の英語版アップロード

一部修正した箇所があります：
- リンク先に英語版が存在しないものについてはその旨を記載
- リンク先に英語記事が存在するものについて、リンクテキストをリンク先の英語タイトルに差し替え
- 「外部サイト」の訳語を External link に統一（Outside link, Outside siteが混在していました）
- 日本語版記事のリンク先URLに不要なパラメータが残っていたものを削除