### PR TITLE
最終更新日を表示する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gem 'github-pages', group: :jekyll_plugins
 group :jekyll_plugins do
   gem 'jekyll-toc'
   gem 'jekyll-target-blank'
+  gem "jekyll-last-modified-at"
 end
 gem 'jekyll'
 gem 'webrick'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,9 @@ GEM
       octokit (~> 4.0, != 4.4.0)
     jekyll-include-cache (0.2.1)
       jekyll (>= 3.7, < 5.0)
+    jekyll-last-modified-at (1.3.0)
+      jekyll (>= 3.7, < 5.0)
+      posix-spawn (~> 0.3.9)
     jekyll-mentions (1.6.0)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -226,6 +229,7 @@ GEM
       sawyer (~> 0.9)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    posix-spawn (0.3.15)
     public_suffix (4.0.7)
     racc (1.6.1)
     rb-fsevent (0.11.2)
@@ -266,6 +270,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll
+  jekyll-last-modified-at
   jekyll-target-blank
   jekyll-toc
   webrick

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,11 @@
 google_analytics: UA-160716658-1
 plugins:
   - jekyll-redirect-from
+  - jekyll-last-modified-at
 kramdown:
   footnote_backlink: ↑
+last-modified-at:
+  date-format: '%Y-%m-%d'
 sass:
   sass_dir: _sass
 url: https://utelecon.adm.u-tokyo.ac.jp

--- a/_config.yml
+++ b/_config.yml
@@ -27,3 +27,15 @@ defaults:
       path: en
     values:
       lang: en
+      image: /assets/images/ogp.png
+      toc: true
+  -
+    scope:
+      path: articles
+    values:
+      updated_at: true
+  -
+    scope:
+      path: en/articles
+    values:
+      updated_at: true

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,9 +7,24 @@
     <h1 class="title">{{ h1 }}</h1>
   {% endif %}
 
+  {% if page.updated_at %}
+    <div style="text-align: right;">
+      {%- if page.lang == "en" -%}
+        Last Updated
+      {%- else -%}
+        最終更新日
+      {%- endif -%}
+    : {% if page.updated_at == true -%}
+        {%- last_modified_at -%}
+      {%- else -%}
+        {{ page.updated_at }}
+      {%- endif -%}
+    </div>
+  {% endif %}
   {% assign toc = content | toc_only %}
   {% assign toc_stripped = toc | strip_html | strip %}
   {% if page.toc and toc_stripped != "" %}
+
     <section class="main__toc">
       <h2>{% if page.lang == "en" %}Table of Contents{% else %}目次{% endif %}</h2>
 {{ toc }}


### PR DESCRIPTION
ページのフロントマターに
```yml
updated_at: true
```
と書くとgit由来の最終更新日が表示されます．

```yml
updated_at: 2020-03-08
```
などと書くと，その文字列が最終更新日として表示されます．

しかし，`updated_at: true`を書き込む更新が最終更新として扱われてしまい，悲しい……  
解決策を思いついたらDraftが外れます．