### PR TITLE
fix utokyo_vpn/index.md as _help_security_education.html

### DIFF
--- a/utokyo_vpn/index.md
+++ b/utokyo_vpn/index.md
@@ -41,7 +41,7 @@ UTokyo VPN経由で東京大学附属図書館が契約・提供する電子ジ�
 </details>
 <details>
 	<summary>所定の時期に情報セキュリティ教育の受講を完了しなかった場合</summary>
-	所定の期間内に情報セキュリティ教育を受講していない場合に表示されるエラーです．UTokyo VPNの利用には情報セキュリティ教育の受講が必須です．情報セキュリティ教育の受講は，所定の受講期間を過ぎていてもITC-LMSから可能となっているので，受講してください．そのうえで，<a href="https://www.u-tokyo.ac.jp/adm/dics/ja/securityeducationvideo.html">情報セキュリティ教育のページ</a>の下部の「お問い合わせ」から，今後の対応についてお問い合わせください．
+	UTokyo VPNの利用には情報セキュリティ教育の受講が必須です．情報セキュリティ教育の受講自体は，所定の受講期間を過ぎていてもITC-LMSから可能となっているので，受講してください．そのうえで，<a href="https://www.u-tokyo.ac.jp/adm/dics/ja/securityeducationvideo.html">情報セキュリティ教育のページ</a>の下部の「お問い合わせ」から，今後の対応についてお問い合わせください．
 	<div>それでもうまくいかなければ，<a href="/support/">サポート窓口</a>に相談してください．</div>
 </details>
 

--- a/utokyo_vpn/index.md
+++ b/utokyo_vpn/index.md
@@ -41,7 +41,8 @@ UTokyo VPN経由で東京大学附属図書館が契約・提供する電子ジ�
 </details>
 <details>
 	<summary>所定の時期に情報セキュリティ教育の受講を完了しなかった場合</summary>
-	当該年度のUTokyo VPNの利用資格が停止されますので，基本的に年度末までUTokyo VPNを利用することはできません．未受講者への対応に関しては， <code>jouhousecurity.adm __at__gs.mail.u-tokyo.ac.jp</code>（<code>__at__</code>は@に変更）まで，UTokyo Accountのユーザー名（10桁の共通ID）を添えてお問い合わせください．
+  所定の期間内に情報セキュリティ教育を受講していない場合に表示されるエラーです．UTokyo VPNの利用には情報セキュリティ教育の受講が必須です．情報セキュリティ教育の受講は，所定の受講期間を過ぎていてもITC-LMSから可能となっているので，受講してください．そのうえで，<a href="https://www.u-tokyo.ac.jp/adm/dics/ja/securityeducationvideo.html">情報セキュリティ教育のページ</a>の下部の「お問い合わせ」から，今後の対応についてお問い合わせください．
+  <div>それでもうまくいかなければ，<a href="/support/">サポート窓口</a>に相談してください．</div>
 </details>
 
 ### UTokyo Accountの多要素認証

--- a/utokyo_vpn/index.md
+++ b/utokyo_vpn/index.md
@@ -41,8 +41,8 @@ UTokyo VPN経由で東京大学附属図書館が契約・提供する電子ジ�
 </details>
 <details>
 	<summary>所定の時期に情報セキュリティ教育の受講を完了しなかった場合</summary>
-  所定の期間内に情報セキュリティ教育を受講していない場合に表示されるエラーです．UTokyo VPNの利用には情報セキュリティ教育の受講が必須です．情報セキュリティ教育の受講は，所定の受講期間を過ぎていてもITC-LMSから可能となっているので，受講してください．そのうえで，<a href="https://www.u-tokyo.ac.jp/adm/dics/ja/securityeducationvideo.html">情報セキュリティ教育のページ</a>の下部の「お問い合わせ」から，今後の対応についてお問い合わせください．
-  <div>それでもうまくいかなければ，<a href="/support/">サポート窓口</a>に相談してください．</div>
+	所定の期間内に情報セキュリティ教育を受講していない場合に表示されるエラーです．UTokyo VPNの利用には情報セキュリティ教育の受講が必須です．情報セキュリティ教育の受講は，所定の受講期間を過ぎていてもITC-LMSから可能となっているので，受講してください．そのうえで，<a href="https://www.u-tokyo.ac.jp/adm/dics/ja/securityeducationvideo.html">情報セキュリティ教育のページ</a>の下部の「お問い合わせ」から，今後の対応についてお問い合わせください．
+	<div>それでもうまくいかなければ，<a href="/support/">サポート窓口</a>に相談してください．</div>
 </details>
 
 ### UTokyo Accountの多要素認証


### PR DESCRIPTION
情報セキュリティ教育未受講の場合の対応について，統一できていない箇所があったため統一しました．
