### PR TITLE
fix redirect

### DIFF
--- a/src/lib/RedirectIntegration.ts
+++ b/src/lib/RedirectIntegration.ts
@@ -22,10 +22,12 @@ export default function redirect(): AstroIntegration {
         const files = await Promise.all(promises);
         const redirects = files.flatMap((file) => {
           const { redirect_to, redirect_from } = file.data;
-          const here = relative(pages, file.path).replace(
-            /(?:index)?\.(?:md|mdx|markdown|astro)$/,
-            ""
-          );
+          const here =
+            "/" +
+            relative(pages, file.path).replace(
+              /(?:index)?\.(?:md|mdx|markdown|astro)$/,
+              ""
+            );
           if (typeof redirect_to === "string") {
             return { from: here, to: redirect_to };
           }


### PR DESCRIPTION
たとえば，`/zoom/zoom_signin`が`/zoom/signin/`に飛ぶべきところ，`zoom/signin/` = `/zoom/zoom_signin/zoom/signin/`に飛んでしまうようになっていました．