### PR TITLE
utokyo_wifi is not repost on oc

### DIFF
--- a/src/components/en/systems/utokyo_wifi/index.mdx
+++ b/src/components/en/systems/utokyo_wifi/index.mdx
@@ -1,5 +1,4 @@
 import If from "@components/utils/If.astro";
-import Important from "@components/utils/Important.astro";
 import Apply from "./Apply.mdx";
 import Connect from "./Connect.mdx";
 
@@ -10,33 +9,22 @@ import Connect from "./Connect.mdx";
   */}
 
 <If cond={props.variant === "oc"}>
-  <Important
-    short={props.important}
-    variant="oc"
-    lang="en"
-    system="UTokyo Wi-Fi"
-    prefix="Task"
-    title="Apply for an account"
-  >
-    <Fragment slot="important">
-      <Apply
-        variant="oc"
-        utasOnly
-        support
-        jouhouSecurity= {<a href="/en/utokyo_wifi/#jouhou-security">"Information Security Education" section on UTokyo Wi-Fi page</a>}
-      />
-    </Fragment>
+  - **Task: Apply for an account**
+    <Apply
+      variant="oc"
+      utasOnly
+      support
+      jouhouSecurity= {<a href="/en/utokyo_wifi/#jouhou-security">"Information Security Education" section on UTokyo Wi-Fi page</a>}
+    />
+  - **Task: Try connecting**
+    <Connect
+      deviceDescription="the device you want to connect"
+      applyStep="the step above"
+      connectConfiguration={<a href="/en/utokyo_wifi/#connect-configuration">"Connect Configuration" section on UTokyo Wi-Fi page</a>}
+      support
+    />
 
-    <li>
-      **Task: Try connecting**
-      <Connect
-        deviceDescription="the device you want to connect"
-        applyStep="the step above"
-        connectConfiguration={<a href="/en/utokyo_wifi/#connect-configuration">"Connect Configuration" section on UTokyo Wi-Fi page</a>}
-        support
-      />
-    </li>
-  </Important>
+
   <Fragment slot="else">
     - **Step 1: Check the devices to be used**  
       Laptops, smartphones, and tablets can generally connect to UTokyo Wi-Fi. However, other types of electronic devices and older devices may not be able to connect. For example, devices that do not support WPA2-Enterprise cannot be connected. Please check for updates to the OS and drivers of your devices and update them appropriately before connecting to UTokyo Wi-Fi.


### PR DESCRIPTION
`/en/oc/`でUTokyo Wi-Fiが#importantからいなくなりましたが，それにも関わらず#othersで `(Repost)` となってしまっていました．これの修正です．