### PR TITLE
eduroam関係のobsoleteな記述削除

### DIFF
--- a/src/pages/en/systems/wlan.md
+++ b/src/pages/en/systems/wlan.md
@@ -12,7 +12,7 @@ UTokyo Wi-Fi is a Wi-Fi service available to members of the University of Tokyo 
 
 ## eduroam
 
-[eduroam](https://eduroam.org/) is a wireless LAN service that can be used mutually among universities and research institutes. Members of the University of Tokyo can use eduroam at other universities and research institutes with the same user ID and password as their UTokyo Wi-Fi account. The steps for connecting are the same as those for UTokyo Wi-Fi, so please refer to the [UTokyo Wi-Fi page](/en/utokyo_wifi/). That said, you'll need to substitute the SSID from 0000UTokyo to eduroam.
+[eduroam](https://eduroam.org/) is a wireless LAN service that can be used mutually among universities and research institutes. Members of the University of Tokyo can use eduroam at other universities and research institutes with the same user ID and password as their UTokyo Wi-Fi account. The steps for connecting are the same as those for UTokyo Wi-Fi, so please refer to the [UTokyo Wi-Fi page](/en/utokyo_wifi/). That said, you'll need to substitute the SSID from `0000UTokyo` to `eduroam`.
 
 - Please refer to the [eduroam JP Privacy Policy](https://meatwiki.nii.ac.jp/confluence/x/WYX0BQ) when using eduroam.
 - You can also use eduroam on the University of Tokyo campus, but your connection will be treated as an off-campus network, and you will not be able to use databases, e-journals, e-books, etc. The eduroam service on the University of Tokyo campus is provided for external users, so members should basically use the UTokyo Wi-Fi service on campus.

--- a/src/pages/en/systems/wlan.md
+++ b/src/pages/en/systems/wlan.md
@@ -12,9 +12,7 @@ UTokyo Wi-Fi is a Wi-Fi service available to members of the University of Tokyo 
 
 ## eduroam
 
-[eduroam](https://eduroam.org/) is a wireless LAN service that can be used mutually among universities and research institutes. Members of the University of Tokyo can use eduroam at other universities and research institutes with the same user ID and password as their UTokyo Wi-Fi account <small>(limited to UTokyo Wi-Fi accounts issued after January 31, 2023)</small>.
-
-\* The former "[EDUROAM for u-tokyo.ac.jp members site](https://www.eduroam.itc.u-tokyo.ac.jp/cgi-bin/en/top.cgi)" will stop issuing new accounts on March 31, 2023, and accounts will no longer be available on and after May 1, 2023. Please use your UTokyo Wi-Fi account to use eduroam.
+[eduroam](https://eduroam.org/) is a wireless LAN service that can be used mutually among universities and research institutes. Members of the University of Tokyo can use eduroam at other universities and research institutes with the same user ID and password as their UTokyo Wi-Fi account. The steps for connecting are the same as those for UTokyo Wi-Fi, so please refer to the [UTokyo Wi-Fi page](/en/utokyo_wifi/). That said, you'll need to substitute the SSID from 0000UTokyo to eduroam.
 
 - Please refer to the [eduroam JP Privacy Policy](https://meatwiki.nii.ac.jp/confluence/x/WYX0BQ) when using eduroam.
 - You can also use eduroam on the University of Tokyo campus, but your connection will be treated as an off-campus network, and you will not be able to use databases, e-journals, e-books, etc. The eduroam service on the University of Tokyo campus is provided for external users, so members should basically use the UTokyo Wi-Fi service on campus.

--- a/src/pages/en/utokyo_wifi/index.mdx
+++ b/src/pages/en/utokyo_wifi/index.mdx
@@ -116,9 +116,8 @@ The network of UTokyo, including UTokyo Wi-Fi, is secured by UTokyo Campuswide F
 - There is no limit to the number of devices per account that can be connected to UTokyo Wi-Fi.
 - You cannot delete your UTokyo Wi-Fi account directly. However, you can make it invalid with reissuing a new account by clicking the "New Application" button in the "UTokyo Wi-Fi Account Menu".
 - Please note that UTokyo Wi-Fi may become temporarily unavailable in certain locations or throughout the campus due to trouble. We apologize for any inconvenience, and we will make efforts to deal with the problem quickly.
-- In addition to UTokyo Wi-Fi, UTokyo has other wireless LAN services that are available on campus. All members of and visitors to UTokyo are requested to refer to [Wireless LAN Service at the University of Tokyo](https://www.u-tokyo.ac.jp/adm/dics/ja/wlan.html) page before using UTokyo Wi-Fi and use the service appropriately.
-  - You will be able to use UTokyo Wi-Fi account user ID and password to connect to [eduroam](https://eduroam.jp/en), a wireless LAN service that allows mutual use among universities and research institutions.
-    - Only UTokyo Wi-Fi accounts issued after January 31, 2023 will be eligible for this.
+- In addition to UTokyo Wi-Fi, UTokyo has other wireless LAN services that are available on campus. If you're a member of the UTokyo, please refer to the [Wireless LAN Services for the Members of the University of Tokyo](/en/systems/wlan) page. If you're from outside the university, consult the [Wireless LAN Service at the University of Tokyo](https://www.u-tokyo.ac.jp/adm/dics/ja/wlan.html) page for proper use.
+  - Using your UTokyo Wi-Fi account's User ID and password, you can connect to the [eduroam](https://eduroam.jp/en) wireless LAN service, which allows mutual use across various universities and research institutions. For details, see the [eduroam section on the Wireless LAN Services for the Members of the University of Tokyo page](/en/systems/wlan#eduroam).
 - If you are in charge of a network of your department,  please also refer to [the Information on UTokyo Portal](https://univtokyo.sharepoint.com/sites/utokyoportal/wiki/d/UTokyo_WiFi_Management.aspx).
 
 ## Troubleshooting and Inquiries

--- a/src/pages/systems/wlan.md
+++ b/src/pages/systems/wlan.md
@@ -13,9 +13,7 @@ UTokyo Wi-Fiは，東京大学の構成員が教育・研究を目的として�
 
 ## eduroam
 
-[eduroam](https://eduroam.jp/)は，大学や研究機関等での相互利用が可能な無線LANサービスです．東京大学の構成員は，他大学・機関等において，UTokyo Wi-Fiアカウントと同じユーザーID・パスワードでeduroamを利用することができます<small>（2023年1月31日以降に発行したUTokyo Wi-Fiアカウントに限ります）</small>．
-
-※旧「[東京大学EDUROAMユーザー情報管理システム](https://www.eduroam.itc.u-tokyo.ac.jp/cgi-bin/ja/top.cgi)」のアカウントは，2023年3月31日をもって新規発行を終了し，2023年5月1日以降は利用できなくなります．今後，eduroamはUTokyo Wi-Fiアカウントでご利用ください．
+[eduroam](https://eduroam.jp/)は，大学や研究機関等での相互利用が可能な無線LANサービスです．東京大学の構成員は，他大学・機関等において，UTokyo Wi-Fiアカウントと同じユーザーID・パスワードでeduroamを利用することができます．具体的な接続の手順はUTokyo Wi-Fiと同様なので，[UTokyo Wi-Fiのページ](/utokyo_wifi/)を参照してください．ただし，SSIDを`0000UTokyo`から`eduroam`に読み替えてください．
 
 - 利用の際は，[eduraom JP プライバシーポリシー](https://meatwiki.nii.ac.jp/confluence/x/WYX0BQ)も参照してください．
 - 東京大学のキャンパス内でも利用できますが，学外扱いのネットワークに接続され，データベース・電子ジャーナル・電子ブック等の利用もできません．東京大学キャンパス内のeduroamサービスは学外者向けに提供しているものですので，構成員は学内では基本的にUTokyo Wi-Fiを利用してください．

--- a/src/pages/utokyo_wifi/index.mdx
+++ b/src/pages/utokyo_wifi/index.mdx
@@ -114,7 +114,7 @@ UTokyo Wi-Fiを含む本学のネットワークでは，全学セキュリテ�
 - UTokyo Wi-Fiのアカウントを直接削除することはできません．ただし，再度「UTokyo Wi-Fiアカウントメニュー」の「新規申請」ボタンを押してアカウントを発行し直すことで，既存のアカウントは無効になります．
 - UTokyo Wi-Fiは一時的に特定の場所，または学内全域でトラブルが発生して利用に支障が出ることがあります．ご不便をおかけいたしますが，速やかに対応できるよう努めてまいりますので，ご理解ください．
 - 東京大学には，UTokyo Wi-Fiの他にも学内で共通に利用できる無線LANサービスがあります．東京大学の構成員の方は「[東京大学構成員の無線LAN利用](/systems/wlan)」のページを，学外の方は「[東京大学での無線LAN利用](https://www.u-tokyo.ac.jp/adm/dics/ja/wlan.html)」のページをそれぞれ参照し，適切に利用してください．
-    - UTokyo Wi-FiアカウントのユーザーIDとパスワードを用いて，大学や研究機関等での相互利用が可能な無線LANサービス[eduroam](https://eduroam.jp/)に接続することができます<small>（2023年1月31日以降に発行したUTokyo Wi-Fiアカウントに限ります）</small>．詳細は[「東京大学構成員の無線LAN利用」のページの「eduroam」の項](/systems/wlan#eduroam)を参照してください．
+    - UTokyo Wi-FiアカウントのユーザーIDとパスワードを用いて，大学や研究機関等での相互利用が可能な無線LANサービス[eduroam](https://eduroam.jp/)に接続することができます．詳細は[「東京大学構成員の無線LAN利用」のページの「eduroam」の項](/systems/wlan#eduroam)を参照してください．
 - いくつかの教室・会議室では，UTokyo Wi-Fiアカウントで接続できる有線ポートが提供されています（原則として教職員向け）．詳細は「[教室等の有線接続サービスについて](wired_lan)」をご覧ください．
 - 部局のネットワーク担当者の方は，[UTokyo Portalの情報](https://univtokyo.sharepoint.com/sites/utokyoportal/wiki/d/UTokyo_WiFi_Management.aspx)も参照してください．
 


### PR DESCRIPTION
ちょっと不親切だったので附記：
- systems/wlan.md : UTokyo Wi-Fi の更新絡みの古い記述をまとめて削除
  - ついでに，eduroamの接続方法の説明を /utokyo_wifi/ に飛ばした（情報セキュリティ教育未受講でeduroamもアカウントが消える話は明示的に回収したほうがいいですかね……？それは各構成員／部局宛ての通知の際に言ってほしい……）
- utokyo_wifi/index.mdx : これも更新の過渡期の内容を削除
- それぞれ英語版も同じような対応をしています． /en/utokyo_wifi/index.mdx は前後の部分の英訳が更新されていなかったので，ついでに修正しています．