### PR TITLE
Preview build/deploy in GitHub actions

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 18
-          cache: ''
+          cache: 'npm'
           cache-dependency-path: package-lock.json
 
       - name: Install

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,0 +1,41 @@
+name: Build and Deploy to Netlify
+on:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout your repository using git
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: ''
+          cache-dependency-path: package-lock.json
+
+      - name: Install
+        run: |
+          npm install
+
+      - name: Build
+        run: |
+          npm run build
+
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v2.1
+        with:
+          publish-dir: dist
+          production-branch: master
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Preview for #${{ github.event.number }}"
+          enable-pull-request-comment: true
+          overwrites-pull-request-comment: true
+          enable-commit-comment: false
+          enable-github-deployment: false
+          alias: deploy-preview-${{ github.event.number }}
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 10


### PR DESCRIPTION
従来Netlify側で行っていたビルドをGitHub Actionsで行うようにします．

Netlify側で変更する必要のある設定項目は次のとおりです．
`Site configuration` -> `Build & deploy` ->
- `Build settings` -> `Build status` = `Stopped builds`
- `Branches and deploy contexts` -> `Deploy Previews` = `None`

GitHub側で新たに設定する環境変数は次のとおりです．
- NETLIFY_AUTH_TOKEN: [NetlifyのアカウントページからPersonal access tokensを取得する](https://docs.netlify.com/cli/get-started/#obtain-a-token-in-the-netlify-ui)必要があります．
- NETLIFY_SITE_ID: Netlifyの`Site configuration` -> `Site information` -> `Site ID`です．