### PR TITLE
explicitly disable formatOnSave in mdx

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,6 @@
 {
+  "[mdx]": {
+    "editor.formatOnSave": false
+  },
   "mdx.experimentalLanguageServer": true
 }


### PR DESCRIPTION
説明会をやったところ意図しないformatが起きてしまったため，明示的にフォーマットしないように設定します．
そもそもIAL周りをprettierは知らないので，フォーマットすると悲しくなります．