### PR TITLE
20231012 google classroom

### DIFF
--- a/src/pages/en/online/tools.md
+++ b/src/pages/en/online/tools.md
@@ -50,7 +50,7 @@ ITC-LMS is UTokyo’s learning management system. It provides functions such as 
 Google Classroom is a tool provided by Google as part of Google Workspace, which allows you to distribute materials and submit assignments in class.
 
 - **[Google Classroom Official Site (external site)](https://edu.google.com/intl/en_ALL/products/classroom/)**
-- **[How to Use Google Classroom (external site)](https://sites.google.com/a/hi-tech.ac.jp/cai-liao-li-xue-xiangkeyoutube-dong-hua/s/google-classroomno-shii-fang)** (in Japanese)：A web page summarizing basic use of Google Classroom.
+- **[How to Use Google Classroom (external site)](https://www.tsu-cc.ac.jp/campus/classroom/teacher/)** (in Japanese)：A web page summarizing basic use of Google Classroom.
 - **[Online Class Information Exchange Meeting #14: Useful Tools for Online Class (3) Google Classroom](/events/luncheon/2020-07-15/)** (in Japanese): This page provides a presentation material and video on how to use Google Classroom in online classes. (The video is for UTokyo members only.)
 
 

--- a/src/pages/online/tools.md
+++ b/src/pages/online/tools.md
@@ -47,9 +47,9 @@ ITC-LMSは東京大学の学習管理システムです．授業資料の配布�
 
 
 ### Google Classroom
-Google Classroomは，Google Workspaceの一部として提供されいる学習管理ツールで，授業における資料の配布・課題提出などが行えるものです．
+Google Classroomは，Google Workspaceの一部として提供されている学習管理ツールで，授業における資料の配布・課題提出などが行えるものです．
 
-- **[Google Classroomの使い方（外部サイト）](https://sites.google.com/a/hi-tech.ac.jp/cai-liao-li-xue-xiangkeyoutube-dong-hua/s/google-classroomno-shii-fang)**：基本的な使い方がまとまっています．
+- **[Google Classroomの使い方（外部サイト）](https://www.tsu-cc.ac.jp/campus/classroom/teacher/)**：基本的な使い方がまとまっています．
 - **[オンライン授業情報交換会 第14回 オンライン授業で使えるツール(3) Google Classroom](/events/luncheon/2020-07-15/)**：Google Classroom の授業における使い方に関する資料と動画があります（動画のみ学内限定公開）．
 
 


### PR DESCRIPTION
Google Classroomの説明を飛ばしていた八戸工業大学のページにアクセスできない形になっていたため、三重短期大学のページを代わりに貼りました