### PR TITLE
20231101 fix centering

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,12 +2,12 @@
 
 :is(main) {
   word-wrap: break-word;
-  :lang(ja) {
+  &:lang(ja) {
     @media (max-width: 640px) {
       text-align: left;
     }
   }
-  :lang(en) {
+  &:lang(en) {
     hyphens: auto;
   }
   font-size: 1.125rem;


### PR DESCRIPTION
- `main.scss` 内の `:lang(ja)` セレクタが `main` 要素のすべての子要素にわたるように書かれていたため、画面幅が小さいときに `.center` クラスが効かないバグが生じていた
- `&`をつけることで `main` にのみ `text-align: left;` を適用するように修正