### PR TITLE
Add workflow_dispatch to Netlify workflow

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -1,6 +1,9 @@
 name: Build and Deploy to Netlify
+
 on:
   pull_request:
+  workflow_dispatch:
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
workflow_dispatchトリガをNetlifyのworkflowに追加します．

dependabotが出したPR等で手動でPreviewを吐かせるのに必要です（最近の更新に影響を受ける場合を考慮し，走らせる前に手動で`@dependabot rebase`を実行したほうがよいでしょうね）．
