### PR TITLE
表示するnoticeの数を4+4から8+4に変更

### DIFF
--- a/src/components/pages/Notice.astro
+++ b/src/components/pages/Notice.astro
@@ -32,7 +32,7 @@ for (const notice of notices) {
   const content = notice.content[lang] ?? notice.content.ja;
   if (!content) continue;
 
-  if (!strip || contents.length < (notice.important ? 8 : 4)) {
+  if (!strip || contents.length < (notice.important ? 12 : 8)) {
     contents.push({ date: notice.date, content });
   }
 }


### PR DESCRIPTION
表示するnoticeの数を増やし、多くのnoticeが表示されるようにします。

Current: [https://utelecon.adm.u-tokyo.ac.jp/](https://utelecon.adm.u-tokyo.ac.jp/)
After: [https://deploy-preview-924--utelecon.netlify.app/](https://deploy-preview-924--utelecon.netlify.app/)