### PR TITLE
Fix `List of past notice is here` link to point at `/en/notice`

### DIFF
--- a/src/pages/en/index.mdx
+++ b/src/pages/en/index.mdx
@@ -40,7 +40,7 @@ import Notice from '@components/pages/Notice.astro'
 
 <Notice lang="en" strip />
 
-[List of past notice is here](/notice/)
+[List of past notice is here](/en/notice/)
 
 ## ICT Systems
 


### PR DESCRIPTION
英語版トップページの"List of past notice is here"が日本語版のnoticeに向いていたので，英語版にリンク先を変更します．