### PR TITLE
Add editor settings (word wrap, suggest, unicode highlight)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,22 @@
 {
-  "[mdx]": {
-    "editor.formatOnSave": false
+  "[markdown]": {
+    "editor.wordWrap": "on",
+    "editor.suggest.showWords": false,
+    "editor.unicodeHighlight.allowedCharacters": {
+      "，": true,
+      "．": true,
+      "　": true,
+    },
   },
-  "mdx.experimentalLanguageServer": true
+  "[mdx]": {
+    "editor.wordWrap": "on",
+    "editor.suggest.showWords": false,
+    "editor.unicodeHighlight.allowedCharacters": {
+      "，": true,
+      "．": true,
+      "　": true,
+    },
+    "editor.formatOnSave": false,
+  },
+  "mdx.experimentalLanguageServer": true,
 }


### PR DESCRIPTION
vscodeのエディタ設定を追加し，markdown/mdxで次の設定を追加します．

- 行の折り返しを有効にします．
- 単語のsuggestionを無効にします（入力した文章がまるごと提案されて煩わしい）
- `，`, `．`, `　`に黄色い四角がつくのを防ぎます．

`.astro`など他のファイルではコードを書くことが多く，干渉の危険があるため除外しました．