### PR TITLE
generate en of email address consolidation

### DIFF
--- a/src/components/en/systems/utokyo_wifi/Apply.mdx
+++ b/src/components/en/systems/utokyo_wifi/Apply.mdx
@@ -37,8 +37,8 @@ import ApplyHelpMFA from "./ApplyHelpMFA.mdx";
         <Fragment slot="else">
           Follow the instructions below to change the email address to which the notification email is sent.
 
-          - For students: Log in to [UTAS](https://utas.adm.u-tokyo.ac.jp/campusweb/campusportal.do) and set "E-MAIL 1" in the "Student Information" menu (note that the "E-MAIL 2" address cannot be used as the UTokyo Wi-Fi email address).
-          - For faculty members: Log in to [the Personnel Information MyWeb](https://univtokyo.sharepoint.com/sites/utokyoportal/wiki/d/Personal_information_and_ID_card.aspx) and set your "学内メールアドレス" (Campus Email Address) field in the "パーソナルメニュー" (Personal Menu). * The email address for this purpose must end with `u-tokyo.ac.jp`
+          - For students <small>including accounts that are both students and faculty and staff members</small>: Log in to [UTAS](https://utas.adm.u-tokyo.ac.jp/campusweb/campusportal.do) and set "E-MAIL 1" in the "Student Information" menu (note that the "E-MAIL 2" address cannot be used as the UTokyo Wi-Fi email address).
+          - For faculty and staff members <small>excluding accounts that are both students and faculty and staff members</small>: Log in to [the Personnel Information MyWeb](https://univtokyo.sharepoint.com/sites/utokyoportal/wiki/d/Personal_information_and_ID_card.aspx) and set your "学内メールアドレス" (Campus Email Address) field in the "パーソナルメニュー" (Personal Menu). * The email address for this purpose must end with `u-tokyo.ac.jp`
         </Fragment>
       </If>
         Please note that it will take some time for the change to take effect, so please apply for an account after a day you registered your email.

--- a/src/pages/en/utokyo_account/index.mdx
+++ b/src/pages/en/utokyo_account/index.mdx
@@ -100,9 +100,9 @@ If you have registered your email address in advance on one of the following, yo
   1. Click "Add sign-in method" button.
   1. In the "Which method would you like to add?" field, select "Email" and click "Add".
   1. Follow the instructions on the screen.
-- (Students only) "E-MAIL 1" field on the "Register Address Update, etc." page in the "Student Info" section of [UTAS](https://utas.adm.u-tokyo.ac.jp/campusweb/campusportal.do).
+- (For students <small>including accounts that are both students and faculty and staff members</small>) "E-MAIL 1" field on the "Register Address Update, etc." page in the "Student Info" section of [UTAS](https://utas.adm.u-tokyo.ac.jp/campusweb/campusportal.do).
   - For new students, the email address registered on https://utas-ew.adm.u-tokyo.ac.jp/ is set as "E-MAIL 1."
-- (Faculty and staff members only) "学内メールアドレス" (Campus Email Address) in the "パーソナルメニュー" (Personal Menu) of the [Personnel Information Myweb](https://univtokyo.sharepoint.com/sites/utokyoportal/wiki/d/Personal_information_and_ID_card.aspx)
+- (For faculty and staff members <small>excluding accounts that are both students and faculty and staff members</small>) "学内メールアドレス" (Campus Email Address) in the "パーソナルメニュー" (Personal Menu) of the [Personnel Information Myweb](https://univtokyo.sharepoint.com/sites/utokyoportal/wiki/d/Personal_information_and_ID_card.aspx)
   - The email address for this purpose must end with `u-tokyo.ac.jp`.
 
 The procedure for resetting the password is as follows.


### PR DESCRIPTION
#931 の英語です．気になったこと：
- uteleconにおいては，原則教職員を `faculty and staff members` と呼んでいる．
- 一方で，ここで「学生かつ教職員のアカウント」を表現しようとすると `both student and faculty and staff members` というわかりにくい表現ができてしまう．
- GPT-4に相談したところ，「現状でもまあ読めるよ，なお `both students and members of the faculty and staff` と直せばわかりやすいね（大意）」という答えを得ていますが，本PRでは原則の呼び方に則って書きました．