### PR TITLE
remove macOS 11 from supported versions for UTokyo VPN

### DIFF
--- a/src/pages/en/utokyo_vpn/index.md
+++ b/src/pages/en/utokyo_vpn/index.md
@@ -24,7 +24,7 @@ You cannot access e-journals and e-books subscribed by UTokyo Library via UTokyo
 
 **Device Types and OS for VPN:** UTokyo VPN is accessible on the following versions of Windows and macOS. 
 - Windows: Windows 10, 11
-- macOS: macOS 11.x Big Sur, 12 Monterey, 13 Ventura, 14 Sonoma
+- macOS: macOS 12 Monterey, 13 Ventura, 14 Sonoma
 
 You can use UTokyo VPN on iPhone, Android, and other mobile devices, though we currently provide limited English manuals for them. If you use it on these mobile devices, please keep the OS and dedicated app properly updated while using it.
 

--- a/src/pages/utokyo_vpn/index.md
+++ b/src/pages/utokyo_vpn/index.md
@@ -27,7 +27,7 @@ UTokyo VPN経由で東京大学附属図書館が契約・提供する電子ジ�
 **利用できる端末の種類:** UTokyo VPNは，WindowsやmacOSなどのコンピュータで利用できます．サポートされているバージョンはそれぞれ以下の通りです．
 
 - Windows: Windows 10, 11
-- macOS: macOS 11.x Big Sur, 12 Monterey, 13 Ventura, 14 Sonoma
+- macOS: macOS 12 Monterey, 13 Ventura, 14 Sonoma
 
 また，AndroidやiPhone，iPadなどのモバイル端末からも利用可能です．OSや専用のアプリを適切にアップデートしながら利用してください．
 


### PR DESCRIPTION
Secure Client 5.1.3.62になってmacOS 11がunsupportedになったので、利用できる端末の種類からmacOS 11を削除しました。