### PR TITLE
コードブロックのスタイルを明るくする

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
     remarkRehype: {
       footnoteLabelProperties: { className: ["visually-hidden"] },
       footnoteLabelTagName: "b",
+    },
+    shikiConfig: {
+      theme: "min-light",
     }
   },
   publicDir: "src/pages",


### PR DESCRIPTION
現状ではコードブロックの配色が暗く、視認性が低くなっています。このPRでは、コードブロックのスタイルを明るく見やすいものへと変更します。

サンプル：[https://deploy-preview-1077--utelecon.netlify.app/en/notice/2022/utas_lms_failure/](https://deploy-preview-1077--utelecon.netlify.app/en/notice/2022/utas_lms_failure/)