### PR TITLE
Cache `node_modules`

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -29,8 +29,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+      - name: Setup node_modules Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
       - name: Install
         run: |
           npm install

--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -15,8 +15,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+      - name: Setup node_modules Cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
       - name: Install
         run: |
           npm install

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -209,7 +209,6 @@ const resolvedBreadcrumb =
     #content {
       /* so that the content does not overflow the viewport */
       min-width: 0;
-      flex-grow: 1;
     }
   }
   @media screen and (max-width: calc(768px + $toc-width + $article-gap)) {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -209,6 +209,7 @@ const resolvedBreadcrumb =
     #content {
       /* so that the content does not overflow the viewport */
       min-width: 0;
+      flex-grow: 1;
     }
   }
   @media screen and (max-width: calc(768px + $toc-width + $article-gap)) {


### PR DESCRIPTION
- Cache `node_modules` so that build artifacts (especially images) are reused