### PR TITLE
add flex-grow to #content

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -209,6 +209,7 @@ const resolvedBreadcrumb =
     #content {
       /* so that the content does not overflow the viewport */
       min-width: 0;
+      flex-grow: 1;
     }
   }
   @media screen and (max-width: calc(768px + $toc-width + $article-gap)) {


### PR DESCRIPTION
- Fixed layout when content is short
  - e.g. compare these pages
    - [current `/docs`](https://utelecon.adm.u-tokyo.ac.jp/docs/)
    - [fixed `/docs`](https://deploy-preview-1106--utelecon.netlify.app/docs/)