### PR TITLE
Make `TrailingSlash` integration work on Windows

### DIFF
--- a/src/lib/TrailingSlashIntegration.ts
+++ b/src/lib/TrailingSlashIntegration.ts
@@ -1,18 +1,20 @@
+import fs from "node:fs/promises";
+import { join, normalize, parse } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { AstroIntegration, RouteData } from "astro";
-import { fileURLToPath } from "url";
-import fs from "fs/promises";
-import { join, parse } from "path";
 
 export default function trailingSlash(): AstroIntegration {
   return {
-    name: "redirect",
+    name: "trailing-slash",
     hooks: {
       "astro:build:done": async ({ dir, routes }) => {
         await Promise.all(
           dedupe(routes)
             .filter(
               ({ component, pathname }) =>
-                parse(component).name !== "index" && !component.endsWith("/") && pathname !== "/404"
+                parse(component).name !== "index" &&
+                !component.endsWith("/") &&
+                pathname !== "/404",
             )
             .map(async ({ pathname }) => {
               if (!pathname) return;
@@ -20,12 +22,12 @@ export default function trailingSlash(): AstroIntegration {
               const sourceDir = join(fileURLToPath(dir), pathname);
               const destination = join(
                 fileURLToPath(dir),
-                pathname.replace(/\/$/, "") + ".html"
+                `${pathname.replace(/\/$/, "")}.html`,
               );
               await fs.rename(source, destination);
               const files = await fs.readdir(sourceDir);
               if (files.length === 0) await fs.rmdir(sourceDir);
-            })
+            }),
         );
       },
     },
@@ -34,6 +36,6 @@ export default function trailingSlash(): AstroIntegration {
 
 function dedupe(routes: RouteData[]): RouteData[] {
   return Array.from(
-    new Map(routes.map((route) => [route.route, route])).values()
+    new Map(routes.map((route) => [normalize(route.route), route])).values(),
   );
 }


### PR DESCRIPTION
- On Windows, there are two possible values of `RouteData.route` value for a same route (e.g. `/en/compare`): `/en/compare` and `/en\\compare`. To use its value as a unique key of a route, we must normalize it.