### PR TITLE
Fix broken css in /utokyo_account/mfa/initial/

### DIFF
--- a/src/components/pages/mfa/BaseTabSelectorButton.astro
+++ b/src/components/pages/mfa/BaseTabSelectorButton.astro
@@ -135,6 +135,7 @@ function labelProps(selection: Selection) {
     font-weight: bold;
     color: $main-color;
     margin: 0 0 0 0.5em;
+    flex-shrink: 0;
   }
 
   button :global(p) {


### PR DESCRIPTION
環境によるかもしれません。壊れているのは主に英語です。
before:
https://utelecon.adm.u-tokyo.ac.jp/en/utokyo_account/mfa/initial/#first
after:
https://deploy-preview-1144--utelecon.netlify.app/en/utokyo_account/mfa/initial/#first
https://deploy-preview-1144--utelecon.netlify.app/en/utokyo_account/mfa/initial/#alternative
https://deploy-preview-1144--utelecon.netlify.app/utokyo_account/mfa/initial/#first
https://deploy-preview-1144--utelecon.netlify.app/utokyo_account/mfa/initial/#alternative
![image](https://github.com/user-attachments/assets/e7d41fa9-e8bc-44f9-89c0-16e98d8e1d8f)

