### PR TITLE
fix sass deprecation

### DIFF
--- a/src/layouts/Footer/Buttons.astro
+++ b/src/layouts/Footer/Buttons.astro
@@ -128,6 +128,7 @@ const supportUrl = {
       .icon {
         display: flex;
         align-items: center;
+        transition: all 0.2s ease-in-out;
 
         @media not all and (max-width: 768px) {
           background-color: $footer-background-color;
@@ -157,12 +158,12 @@ const supportUrl = {
             color: #fff;
           }
         }
-
-        transition: all 0.2s ease-in-out;
       }
 
       .description {
         text-align: center;
+        white-space: nowrap;
+        transition: all 0.2s ease-in-out;
 
         @media not all and (max-width: 768px) {
           margin-top: 0.375rem;
@@ -174,10 +175,6 @@ const supportUrl = {
           padding: 0 0.5rem;
           font-size: 1.25rem;
         }
-
-        white-space: nowrap;
-
-        transition: all 0.2s ease-in-out;
       }
 
       @media not all and (max-width: 768px) {

--- a/src/layouts/Footer/index.astro
+++ b/src/layouts/Footer/index.astro
@@ -55,12 +55,12 @@ const topUrl = {
   footer.footer {
     background-color: $footer-background-color;
     color: white;
+    padding: 2rem 4rem 8rem;
     :link,
     :visited {
       color: white;
       text-decoration: none;
     }
-    padding: 2rem 4rem 8rem;
     @media (max-width: 768px) {
       padding: 2rem 2rem 8rem;
     }

--- a/src/layouts/Header/Navigation.astro
+++ b/src/layouts/Header/Navigation.astro
@@ -42,16 +42,15 @@ const data: Navigation[] = {
   @import "./variables";
 
   nav.header {
+    grid-row: 2 / 3;
+    grid-column: 1 / 3;
+    display: block;
     color: white;
     :link,
     :visited {
       color: white;
       text-decoration: none;
     }
-
-    grid-row: 2 / 3;
-    grid-column: 1 / 3;
-    display: block;
 
     @media not all and (max-width: $header-hamburger-breakpoint) {
       & > ul {

--- a/src/layouts/Header/index.astro
+++ b/src/layouts/Header/index.astro
@@ -151,13 +151,13 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
     );
   }
   header.header {
+    @include background;
     color: white;
     :link,
     :visited {
       color: white;
       text-decoration: none;
     }
-    @include background;
   }
   @media (max-width: $header-hamburger-breakpoint) {
     .primary {
@@ -213,11 +213,11 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
   }
 
   .title {
+    font-weight: normal;
     margin: 0.5rem 2rem 0.25rem 2rem;
     @media (max-width: $header-hamburger-breakpoint) {
       margin: 0.5rem 1rem 0.5rem 0;
     }
-    font-weight: normal;
     &__link {
       display: block;
     }

--- a/src/layouts/Toc.astro
+++ b/src/layouts/Toc.astro
@@ -126,16 +126,16 @@ for (const heading of Astro.props.headings) {
         content: "";
         position: absolute;
         border-radius: 50%;
-        top: 1em;
-        @media (pointer: coarse) {
-          top: 1.5em;
-        }
         left: - calc($toc-ul-left-padding / 2);
         width: 4px;
         height: 4px;
         transform: translate(-50%, -50%);
         background: $link-color-light;
         border: 2px solid $white-gray-light;
+        top: 1em;
+        @media (pointer: coarse) {
+          top: 1.5em;
+        }
       }
     }
     ul.toc-h2 {

--- a/src/styles/components/card.scss
+++ b/src/styles/components/card.scss
@@ -1,25 +1,27 @@
 .cards {
   display: grid;
+  margin: 1em 0;
+  padding: 0;
+  grid-auto-rows: 1fr;
+  grid-gap: 1em;
   grid-template-columns: repeat(3, 1fr);
+
   @media (max-width: 896px) {
     grid-template-columns: repeat(2, 1fr);
   }
+
   @media (max-width: 640px) {
     grid-template-columns: 1fr;
   }
-  grid-auto-rows: 1fr;
-  grid-gap: 1em;
-  margin: 1em 0;
-  padding: 0;
 
-  & > li {
+  &>li {
     /* for IE11 */
     display: block;
     display: contents;
   }
 
-  & > a,
-  & > li > a {
+  &>a,
+  &>li>a {
     display: block;
     border: 1px solid $black-gray;
     border-left: 4px solid $heading-color;
@@ -28,6 +30,6 @@
   }
 }
 
-.cards + h2 {
+.cards+h2 {
   margin-top: 1.6em;
 }

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -2,6 +2,9 @@
 
 :is(main) {
   word-wrap: break-word;
+  font-size: 1.125rem;
+  color: $text-color;
+  padding: 2rem 4rem;
 
   &:lang(ja) {
     text-align: justify;
@@ -14,9 +17,6 @@
   &:lang(en) {
     hyphens: auto;
   }
-
-  font-size: 1.125rem;
-  color: $text-color;
 
   @import "components/box";
   @import "components/card";
@@ -31,8 +31,6 @@
   @import "components/table";
   @import "components/top";
   @import "components/utils";
-
-  padding: 2rem 4rem;
 
   @media (min-width: 1024px) {
     max-width: 64rem;


### PR DESCRIPTION
参考: https://sass-lang.com/documentation/breaking-changes/mixed-decls/

<details>
  <summary>現在出ている警告のログ（長いので注意）</summary>

```txt
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
   ╷
6  │ ┌     :link,
7  │ │     :visited {
8  │ │       color: white;
9  │ │       text-decoration: none;
10 │ │     }
   │ └─── nested rule
11 │       padding: 2rem 4rem 8rem;
   │       ^^^^^^^^^^^^^^^^^^^^^^^ declaration
   ╵
    src/layouts/Footer/index.astro 11:5  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
56  │       background-color: $header-background-color-primary;
    │       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
... │
65  │ ┌     :link,
66  │ │     :visited {
67  │ │       color: white;
68  │ │       text-decoration: none;
69  │ │     }
    │ └─── nested rule
    ╵
    src/layouts/Header/index.astro 56:5  background()
    src/layouts/Header/index.astro 70:5  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
57  │ ┌     background-image: linear-gradient(
58  │ │       120deg,
59  │ │       $header-background-color-secondary,
60  │ │       $header-background-color-primary
61  │ │     );
    │ └─────^ declaration
... │
65  │ ┌     :link,
66  │ │     :visited {
67  │ │       color: white;
68  │ │       text-decoration: none;
69  │ │     }
    │ └─── nested rule
    ╵
    src/layouts/Header/index.astro 57:5  background()
    src/layouts/Header/index.astro 70:5  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
127 │ ┌     @media (max-width: $header-hamburger-breakpoint) {
128 │ │       margin: 0.5rem 1rem 0.5rem 0;
129 │ │     }
    │ └─── nested rule
130 │       font-weight: normal;
    │       ^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Header/index.astro 130:5  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
14  │ ┌   &:lang(en) {
15  │ │     hyphens: auto;
16  │ │   }
    │ └─── nested rule
... │
18  │     font-size: 1.125rem;
    │     ^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/styles/main.scss 18:3    @import
    src/styles/layout.scss 16:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
14  │ ┌   &:lang(en) {
15  │ │     hyphens: auto;
16  │ │   }
    │ └─── nested rule
... │
19  │     color: $text-color;
    │     ^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/styles/main.scss 19:3    @import
    src/styles/layout.scss 16:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
   ╷
7  │ ┌   @media (max-width: 640px) {
8  │ │     grid-template-columns: 1fr;
9  │ │   }
   │ └─── nested rule
10 │     grid-auto-rows: 1fr;
   │     ^^^^^^^^^^^^^^^^^^^ declaration
   ╵
    src/styles/components/card.scss 10:3  @import
    src/styles/main.scss 22:11            @import
    src/styles/layout.scss 16:9           root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
7   │ ┌   @media (max-width: 640px) {
8   │ │     grid-template-columns: 1fr;
9   │ │   }
    │ └─── nested rule
... │
11  │     grid-gap: 1em;
    │     ^^^^^^^^^^^^^ declaration
    ╵
    src/styles/components/card.scss 11:3  @import
    src/styles/main.scss 22:11            @import
    src/styles/layout.scss 16:9           root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
7   │ ┌   @media (max-width: 640px) {
8   │ │     grid-template-columns: 1fr;
9   │ │   }
    │ └─── nested rule
... │
12  │     margin: 1em 0;
    │     ^^^^^^^^^^^^^ declaration
    ╵
    src/styles/components/card.scss 12:3  @import
    src/styles/main.scss 22:11            @import
    src/styles/layout.scss 16:9           root stylesheet
                                                                                                                                                                                                                                                                           
Warning: 2 repetitive deprecation warnings omitted.
                                                                                                                                                                                                                                                                           
18:02:33 [WARN] [vite] warning: rewrote @styles/toc.scss to src/styles/toc.scss but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
18:02:33 [WARN] [vite] warning: rewrote @styles/color.scss to src/styles/color.scss but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
18:02:33 [WARN] [vite] warning: rewrote @styles/color.scss to src/styles/color.scss but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
   ╷
52 │ ┌         @media (pointer: coarse) {
53 │ │           top: 1.5em;
54 │ │         }
   │ └─── nested rule
55 │           left: - calc($toc-ul-left-padding / 2);
   │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
   ╵
    src/layouts/Toc.astro 55:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
52  │ ┌         @media (pointer: coarse) {
53  │ │           top: 1.5em;
54  │ │         }
    │ └─── nested rule
... │
56  │           width: 4px;
    │           ^^^^^^^^^^ declaration
    ╵
    src/layouts/Toc.astro 56:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
52  │ ┌         @media (pointer: coarse) {
53  │ │           top: 1.5em;
54  │ │         }
    │ └─── nested rule
... │
57  │           height: 4px;
    │           ^^^^^^^^^^^ declaration
    ╵
    src/layouts/Toc.astro 57:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
52  │ ┌         @media (pointer: coarse) {
53  │ │           top: 1.5em;
54  │ │         }
    │ └─── nested rule
... │
58  │           transform: translate(-50%, -50%);
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Toc.astro 58:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
52  │ ┌         @media (pointer: coarse) {
53  │ │           top: 1.5em;
54  │ │         }
    │ └─── nested rule
... │
59  │           background: $link-color-light;
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Toc.astro 59:9  root stylesheet
                                                                                                                                                                                                                                                                           
Warning: 1 repetitive deprecation warnings omitted.
                                                                                                                                                                                                                                                                           
18:02:34 [WARN] [vite] warning: rewrote @styles/color.scss to src/styles/color.scss but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
7   │ ┌     :link,
8   │ │     :visited {
9   │ │       color: white;
10  │ │       text-decoration: none;
11  │ │     }
    │ └─── nested rule
... │
13  │       grid-row: 2 / 3;
    │       ^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Header/Navigation.astro 13:5  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
7   │ ┌     :link,
8   │ │     :visited {
9   │ │       color: white;
10  │ │       text-decoration: none;
11  │ │     }
    │ └─── nested rule
... │
14  │       grid-column: 1 / 3;
    │       ^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Header/Navigation.astro 14:5  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
7   │ ┌     :link,
8   │ │     :visited {
9   │ │       color: white;
10  │ │       text-decoration: none;
11  │ │     }
    │ └─── nested rule
... │
15  │       display: block;
    │       ^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Header/Navigation.astro 15:5  root stylesheet
                                                                                                                                                                                                                                                                           
18:02:34 [WARN] [vite] warning: rewrote @styles/color.scss to src/styles/color.scss but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
103 │ ┌           @media not all and (max-width: 768px) {
104 │ │             color: #fff;
105 │ │           }
    │ └─── nested rule
... │
108 │           transition: all 0.2s ease-in-out;
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Footer/Buttons.astro 108:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
120 │ ┌         @media (max-width: 768px) {
121 │ │           padding: 0 0.5rem;
122 │ │           font-size: 1.25rem;
123 │ │         }
    │ └─── nested rule
... │
125 │           white-space: nowrap;
    │           ^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Footer/Buttons.astro 125:9  root stylesheet
                                                                                                                                                                                                                                                                           
Deprecation Warning: Sass's behavior for declarations that appear after nested
rules will be changing to match the behavior specified by CSS in an upcoming
version. To keep the existing behavior, move the declaration above the nested
rule. To opt into the new behavior, wrap the declaration in `& {}`.
                                                                                                                                                                                                                                                                           
More info: https://sass-lang.com/d/mixed-decls
                                                                                                                                                                                                                                                                           
    ╷
120 │ ┌         @media (max-width: 768px) {
121 │ │           padding: 0 0.5rem;
122 │ │           font-size: 1.25rem;
123 │ │         }
    │ └─── nested rule
... │
127 │           transition: all 0.2s ease-in-out;
    │           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ declaration
    ╵
    src/layouts/Footer/Buttons.astro 127:9  root stylesheet
```

</details>