### PR TITLE
fix z-index collision

### DIFF
--- a/src/layouts/Toc.astro
+++ b/src/layouts/Toc.astro
@@ -198,6 +198,7 @@ for (const heading of Astro.props.headings) {
       position: sticky;
       top: 1rem;
       pointer-events: none;
+      z-index: 100;
     }
     #toc-toggle {
       display: flex;
@@ -239,7 +240,6 @@ for (const heading of Astro.props.headings) {
       width: 100vw;
       height: 100vh;
       background: transparent;
-      z-index: 100;
       pointer-events: auto;
       aside.toc-open & {
         display: block;
@@ -262,7 +262,6 @@ for (const heading of Astro.props.headings) {
     }
     .toc-open #toc {
       display: block;
-      z-index: 100;
     }
   }
 </style>


### PR DESCRIPTION
- MFA初期設定のページで目次とラジオボタンの上下が乱れる現象への対応
  - [before](https://utelecon.adm.u-tokyo.ac.jp/utokyo_account/mfa/initial/)
  - [after](https://deploy-preview-1149--utelecon.netlify.app/utokyo_account/mfa/initial/)

<details>
<summary>before（画像）</summary>

![image](https://github.com/user-attachments/assets/cdbdbf27-ca46-4386-8577-a4065f8e0cae)

</details>

<details>
<summary>after（画像）</summary>

![image](https://github.com/user-attachments/assets/7adce0e4-cfb6-44b3-955d-7ed74e245de5)

</details>
