### PR TITLE
use absolute path for vite resolve.alias

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,4 @@
+import { fileURLToPath } from "node:url";
 import mdx from "@astrojs/mdx";
 import react from "@astrojs/react";
 import { defineConfig } from "astro/config";
@@ -21,7 +22,7 @@ export default defineConfig({
     plugins: [yaml()],
     resolve: {
       alias: {
-        "@styles": "src/styles",
+        "@styles": fileURLToPath(new URL("./src/styles", import.meta.url)),
       },
     },
     server: {


### PR DESCRIPTION
- ビルド時に出ていたViteの警告を消しました

<details>
<summary>これまで出ていた警告</summary>

```txt
18:26:47 [WARN] [vite] warning: rewrote @styles/toc.scss to src/styles/toc.scss but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
18:26:47 [WARN] [vite] warning: rewrote @styles/color.scss to src/styles/color.scss but was not an abolute path and was not handled by other plugins. This will lead to duplicated modules for the same path. To avoid duplicating modules, you should resolve to an absolute path.
  Plugin: alias
```

</details>