### PR TITLE
workaround not to use rehype-raw

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -14,7 +14,6 @@ import { cleanup } from "./src/lib/CleanupIntegration.js";
 import collectHtmlImages from "./src/lib/CollectHtmlImagesPlugin.js";
 import copyAsset from "./src/lib/CopyAssetIntegration.js";
 import assetFileNames from "./src/lib/AssetFileNames.js";
-import rehypeRaw from "rehype-raw";
 
 // https://astro.build/config
 export default defineConfig({
@@ -49,19 +48,19 @@ export default defineConfig({
           allowNoPosition: true,
         },
       ],
+      collectHtmlImages,
     ],
     remarkRehype: {
       footnoteLabelProperties: { className: ["visually-hidden"] },
       footnoteLabelTagName: "b",
     },
-    rehypePlugins: [rehypeRaw, collectHtmlImages],
     shikiConfig: {
       theme: "min-light",
     },
   },
   scopedStyleStrategy: "where",
   integrations: [
-    mdx({ rehypePlugins: [] }),
+    mdx(),
     react(),
     redirect(),
     externalLinks({

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,6 @@
         "rehype-external-links": "3.0.0",
         "rehype-minify-whitespace": "^6.0.0",
         "rehype-parse": "9.0.0",
-        "rehype-raw": "7.0.0",
         "rehype-remove-comments": "^6.0.0",
         "rehype-remove-empty-attribute": "^4.0.0",
         "rehype-stringify": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "rehype-external-links": "3.0.0",
     "rehype-minify-whitespace": "^6.0.0",
     "rehype-parse": "9.0.0",
-    "rehype-raw": "7.0.0",
     "rehype-remove-comments": "^6.0.0",
     "rehype-remove-empty-attribute": "^4.0.0",
     "rehype-stringify": "10.0.0",


### PR DESCRIPTION
classがカンマ区切りになる問題を解決します．
collectHtmlImagesPlugin を変更していますが，この変更の前後で `dist/_astro` のファイル数が変わらないことを確認しました．