### PR TITLE
add emergency on google storage limit

### DIFF
--- a/src/emergencies/20241101EnGoogleStorageLimit.md
+++ b/src/emergencies/20241101EnGoogleStorageLimit.md
@@ -7,6 +7,7 @@ pattern: "^/en(/|/support/|/google/.*)$"
   Currently, there is a problem in which the service on ECCS Cloud Email displays the message “Storage is full,” “Organization storage full,” “The file is view-only” or “You're out of storage,” and prevents writing operations. The main effects are as follows
   - Unable to upload files to Google Drive
   - Cannot edit Google Docs / Google Spreadsheets / Google Slides
+  - Google Form does not accept response
   - Google Photos does not work.
 
   For the latest information, please refer to [Outage and Maintenance Information](https://univtokyo.sharepoint.com/sites/utokyoaccount/Lists/servicestatus/DispForm.aspx?ID=101&ContentTypeId=0x010077E350E4B86D594C93F01D43B08AD09900D1BA110F28A46C4FAB238B694200CEB3) (UTokyo Account required, in Japanese).

--- a/src/emergencies/20241101EnGoogleStorageLimit.md
+++ b/src/emergencies/20241101EnGoogleStorageLimit.md
@@ -1,0 +1,13 @@
+---
+pattern: "^/en(/|/support/|/google/.*)$"
+---
+
+<div class="box--alert">
+
+  Currently, there is a problem in which the service on ECCS Cloud Email displays the message “Storage is full,” “Organization storage full,” “The file is view-only” or “You're out of storage,” and prevents writing operations. The main effects are as follows
+  - Unable to upload files to Google Drive
+  - Cannot edit Google Docs / Google Spreadsheets / Google Slides
+  - Google Photos does not work.
+
+  For the latest information, please refer to [Outage and Maintenance Information](https://univtokyo.sharepoint.com/sites/utokyoaccount/Lists/servicestatus/DispForm.aspx?ID=101&ContentTypeId=0x010077E350E4B86D594C93F01D43B08AD09900D1BA110F28A46C4FAB238B694200CEB3) (UTokyo Account required, in Japanese).
+</div>

--- a/src/emergencies/20241101GoogleStorageLimit.md
+++ b/src/emergencies/20241101GoogleStorageLimit.md
@@ -6,7 +6,7 @@ pattern: "^(/|/support/|/google/.*)$"
 
   現在，ECCS クラウドメール上のサービスで「空き容量がありません」「組織の空き容量がありません」「このファイルは表示専用です」「保存容量が不足しています」 と表示され，書き込み操作ができなくなる問題が発生しています．主な影響は以下のとおりです：
   - Google Drive　にファイルをアップロードできない
-  - Google ドキュメンt / Google スプレッドシート / Google スライド を編集できない
+  - Google ドキュメント・Google スプレッドシート・Google スライドを編集できない
   - Google フォトが動作しない
 
   最新の情報については[障害・メンテナンス情報](https://univtokyo.sharepoint.com/sites/utokyoaccount/_layouts/15/listform.aspx?PageType=4&ListId=b3a9507a%2Db73e%2D432f%2Db33a%2D6ff9779310f2&ID=101&ContentTypeID=0x010077E350E4B86D594C93F01D43B08AD09900D1BA110F28A46C4FAB238B694200CEB3)（要 UTokyo Account）をご確認ください．

--- a/src/emergencies/20241101GoogleStorageLimit.md
+++ b/src/emergencies/20241101GoogleStorageLimit.md
@@ -5,8 +5,9 @@ pattern: "^(/|/support/|/google/.*)$"
 <div class="box--alert">
 
   現在，ECCS クラウドメール上のサービスで「空き容量がありません」「組織の空き容量がありません」「このファイルは表示専用です」「保存容量が不足しています」 と表示され，書き込み操作ができなくなる問題が発生しています．主な影響は以下のとおりです：
-  - Google Drive　にファイルをアップロードできない
+  - Google ドライブ　にファイルをアップロードできない
   - Google ドキュメント・Google スプレッドシート・Google スライドを編集できない
+  - Google フォームで回答の受付が終了している
   - Google フォトが動作しない
 
   最新の情報については[障害・メンテナンス情報](https://univtokyo.sharepoint.com/sites/utokyoaccount/_layouts/15/listform.aspx?PageType=4&ListId=b3a9507a%2Db73e%2D432f%2Db33a%2D6ff9779310f2&ID=101&ContentTypeID=0x010077E350E4B86D594C93F01D43B08AD09900D1BA110F28A46C4FAB238B694200CEB3)（要 UTokyo Account）をご確認ください．

--- a/src/emergencies/20241101GoogleStorageLimit.md
+++ b/src/emergencies/20241101GoogleStorageLimit.md
@@ -1,0 +1,13 @@
+---
+pattern: "^(/|/support/|/google/.*)$"
+---
+
+<div class="box--alert">
+
+  現在，ECCS クラウドメール上のサービスで「空き容量がありません」「組織の空き容量がありません」「このファイルは表示専用です」「保存容量が不足しています」 と表示され，書き込み操作ができなくなる問題が発生しています．主な影響は以下のとおりです：
+  - Google Drive　にファイルをアップロードできない
+  - Google ドキュメンt / Google スプレッドシート / Google スライド を編集できない
+  - Google フォトが動作しない
+
+  最新の情報については[障害・メンテナンス情報](https://univtokyo.sharepoint.com/sites/utokyoaccount/_layouts/15/listform.aspx?PageType=4&ListId=b3a9507a%2Db73e%2D432f%2Db33a%2D6ff9779310f2&ID=101&ContentTypeID=0x010077E350E4B86D594C93F01D43B08AD09900D1BA110F28A46C4FAB238B694200CEB3)（要 UTokyo Account）をご確認ください．
+</div>

--- a/src/pages/en/support/index.mdx
+++ b/src/pages/en/support/index.mdx
@@ -99,11 +99,15 @@ After submitting the form, a confirmation email and responses to your inquiry wi
 
 <div>Business hours: 24 hours</div>
 
+
+**Due to a problem with ECCS Cloud Email, the mail form is currently unavailable. Please send your inquiry by e-mail according to “If the email form is not working”.**{:.box--alert}
+
 <b class="box center">
-    <a href="https://forms.gle/ASFmXTbgNwncrWL28">Submit an email form</a>
+    {/* <a href="https://forms.gle/ASFmXTbgNwncrWL28">Submit an email form</a> */}
+    <s>Submit an email form</s>
 </b>
 
-<details>
+<details open>
 <summary>If the email form is not working</summary>
 
 If the email form is not working, please send a direct email to `contact@utelecon.zendesk.com`. Please include the following information in your email:

--- a/src/pages/support/index.mdx
+++ b/src/pages/support/index.mdx
@@ -91,11 +91,14 @@ UTokyo Accountで東京大学の情報システムを利用する際には，多
 
 <div>受付時間：24時間</div>
 
+**現在 ECCS クラウドメールで起きている問題により，メールフォームは利用できません．問い合わせは「メールフォームが利用できない場合」にしたがってメールでお送りください．**{:.box--alert}
+
 <b class="box center">
-    <a href="https://forms.gle/ASFmXTbgNwncrWL28">メールフォーム</a>
+    {/* <a href="https://forms.gle/ASFmXTbgNwncrWL28">メールフォーム</a> */}
+    <s>メールフォーム</s>
 </b>
 
-<details>
+<details open>
 <summary>メールフォームが利用できない場合</summary>
 メールフォームが利用できない（アクセスできない，送信できない）場合は，`contact@utelecon.zendesk.com` 宛にメールをお送りいただくこともできます．メールには以下の情報を含めてください．
 


### PR DESCRIPTION
以下のページに Google のサービスが利用できない旨の赤枠を出します．
<img width="924" alt="image" src="https://github.com/user-attachments/assets/4455a3e6-39b7-4047-a449-33f828798ffe">


https://deploy-preview-1249--utelecon.netlify.app
https://deploy-preview-1249--utelecon.netlify.app/google/
https://deploy-preview-1249--utelecon.netlify.app/support/

https://deploy-preview-1249--utelecon.netlify.app/en/
https://deploy-preview-1249--utelecon.netlify.app/en/google/
https://deploy-preview-1249--utelecon.netlify.app/en/support/

また，サポート窓口のメールフォームが利用できなくなっているため，メールフォームが送信できない場合の折りたたみを最初から開いておくなどの調整を行います．
<img width="953" alt="image" src="https://github.com/user-attachments/assets/de0282e4-ffef-4017-9d27-fa6d38f43884">
