### PR TITLE
Experimental: handle redirect from slashed URL

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -1,17 +1,18 @@
 import { fileURLToPath } from "node:url";
-import { join } from "node:path";
-import { parse as parsePath } from "path";
+import { join, parse as parsePath } from "node:path";
 
 export function getDistFilePath(dir: URL, pathname: string, component: string) {
   const base = fileURLToPath(dir);
-  
+
   if (pathname === "/404") {
     return join(base, "404.html");
   }
 
-  if (parsePath(component).name === "index") {
+  const { name, ext } = parsePath(component);
+
+  if (name === "index" && ext && pathname !== component) {
     return join(base, pathname, "index.html");
   }
 
-  return join(base, pathname + ".html");
+  return join(base, `${pathname}.html`);
 }

--- a/src/pages/articles/cosense/index.md
+++ b/src/pages/articles/cosense/index.md
@@ -1,5 +1,7 @@
 ---
 title: Cosenseの基本的な使い方
+redirect_from:
+  - /articles/scrapbox/
 ---
 
 ## この記事のハイライト

--- a/src/pages/articles/scrapbox.md
+++ b/src/pages/articles/scrapbox.md
@@ -1,3 +1,0 @@
----
-redirect_to: "/articles/cosense"
----

--- a/src/pages/en/articles/cosense/index.md
+++ b/src/pages/en/articles/cosense/index.md
@@ -1,5 +1,7 @@
 ---
 title: Basic Use of Cosense
+redirect_from:
+  - /en/articles/scrapbox/
 ---
 
 ## Highlights of This Article

--- a/src/pages/en/articles/scrapbox.md
+++ b/src/pages/en/articles/scrapbox.md
@@ -1,3 +1,0 @@
----
-redirect_to: "/articles/cosense"
----


### PR DESCRIPTION
## 問題

- Astroでは、`build.format` が `preserve` に設定されている（現状）場合、`/foo/`（スラッシュあり）からのリダイレクトも `/foo`（スラッシュなし）からのリダイレクトと同じように扱われてしまう（前者では `dist/foo/index.html` を出力してほしいところ、`dist/foo.html` が出力される）
- さらにGitHub Pagesでは、スラッシュありのURL（`/foo/`）でアクセスするとスラッシュなしのURL（`/foo`）に転送されない
- その結果、`/foo/` からのリダイレクトが一切設定できなくなってしまう

## 修正

- `/foo/` からのリダイレクトを `/foo/index` からのリダイレクトとみなし、強引に `dist/foo/index.html` を生成させる
- 細かな問題点：`dist/foo/index.html` の文面に `/foo/index` という文字列が含まれてしまう

## 備考

- `build.format` を `directory` とすればそもそも問題は生じない（すべてのページが `index.html` で生成される）ため、このようなハックは不要になる