### PR TITLE
５年間で終了するサービスであることの強調説明追加他

### DIFF
--- a/src/pages/en/research_computing/utokyo_azure/faq/index.mdx
+++ b/src/pages/en/research_computing/utokyo_azure/faq/index.mdx
@@ -108,7 +108,7 @@ However, for example, login authentication to the OS running on a virtual machin
 
 <HelpItem lang="en" type="details">
   <Fragment slot="problem">I want to know how to calculate the Free Tier and  Guaranteed Free Tier</Fragment>
-  <Fragment slot="solution">For details on the calculation method, please refer to the subscriotion management page of the [UTokyo Azure : New User Application Page (access limited to the campus network)] (http://azure.itc.u-tokyo.ac.jp/).</Fragment>
+  <Fragment slot="solution">For details on the calculation method, please refer to the UTokyo Azure Usage Fee Policy of the [UTokyo Azure：UTokyo Member-only Site](https://sites.google.com/g.ecc.u-tokyo.ac.jp/utokyo-azure-internal-en).</Fragment>
 </HelpItem>
 
 <HelpItem lang="en" type="details">

--- a/src/pages/en/research_computing/utokyo_azure/index.mdx
+++ b/src/pages/en/research_computing/utokyo_azure/index.mdx
@@ -40,6 +40,10 @@ Operation is performed by the Information Technology Center, the Information Sys
 
 ## Getting Started
 
+<div class="box">
+**Important：**This service will be available for up to five years while the gift credits are provided. There is no decision regarding its continuation after that, so please keep this in mind when considering long-term use. For more information: [UTokyo Azure:UTokyo Member-only Site](https://sites.google.com/g.ecc.u-tokyo.ac.jp/utokyo-azure-internal-en/)
+</div>
+
 - First, please submit an application via the [**UTokyo Azure New Usage Application Page (accessible only within the university network)**](http://azure.itc.u-tokyo.ac.jp/).  
   - Applications can only be submitted by faculty or staff members who can take responsibility for payment if usage fees are incurred. Students who wish to use the service should consult with an appropriate person in a supervisory role, such as their academic advisor.
 

--- a/src/pages/en/research_computing/utokyo_azure/index.mdx
+++ b/src/pages/en/research_computing/utokyo_azure/index.mdx
@@ -36,7 +36,7 @@ Operation is performed by the Information Technology Center, the Information Sys
 
 ## Terms of Use and Related Information
 
-- Terms of use, the amount of gift credits, cases where usage fees may apply, and the rules for calculating charges for each user are provided on the [internal information site](https://sites.google.com/g.ecc.u-tokyo.ac.jp/utokyo-azure-internal/) (accessible with a University of Tokyo Google account --- [ECCS Cloud Mail](/en/google/) --- sign-in required). Please refer to this site for more information.
+- Terms of use, the amount of gift credits, cases where usage fees may apply, and the rules for calculating charges for each user are provided on the [internal information site](https://sites.google.com/g.ecc.u-tokyo.ac.jp/utokyo-azure-internal-en/) (accessible with a University of Tokyo Google account --- [ECCS Cloud Mail](/en/google/) --- sign-in required). Please refer to this site for more information.
 
 ## Getting Started
 

--- a/src/pages/research_computing/utokyo_azure/faq/index.mdx
+++ b/src/pages/research_computing/utokyo_azure/faq/index.mdx
@@ -106,7 +106,7 @@ import HelpItem from "@components/utils/HelpItem.astro";
 
 <HelpItem lang="ja" type="details">
   <Fragment slot="problem">無料分や無料保証枠の計算方法を知りたい</Fragment>
-  <Fragment slot="solution">計算方法の詳細は[UTokyo Azure 新規利用申請ページ（学内ネットワークからのアクセスに限定）](http://azure.itc.u-tokyo.ac.jp/)の管理ページを参照ください．</Fragment>
+  <Fragment slot="solution">計算方法の詳細は[UTokyo Azure 学内者限定情報発信サイト](https://sites.google.com/g.ecc.u-tokyo.ac.jp/utokyo-azure-internal/)にあります UTokyo Azure 利用料金規則 を参照ください．</Fragment>
 </HelpItem>
 
 <HelpItem lang="ja" type="details">

--- a/src/pages/research_computing/utokyo_azure/index.mdx
+++ b/src/pages/research_computing/utokyo_azure/index.mdx
@@ -40,6 +40,10 @@ UTokyo Azure は，このギフトクレジットによる Microsoft Azure の�
 
 ## 使ってみる
 
+<div class="box">
+**重要**：本サービスはギフトクレジットが提供される**5年間という年限があるサービスとなります．**その後の継続については未定なので，長期利用をご検討される場合はその点にご注意ください．詳細は[学内者限定情報の発信サイト](https://sites.google.com/g.ecc.u-tokyo.ac.jp/utokyo-azure-internal/)等もご参照ください．
+</div>
+
 - まず[**UTokyo Azure新規利用申請ページ（学内ネットワークからのアクセスに限定）**](http://azure.itc.u-tokyo.ac.jp/)から利用申請をして下さい．
   - 申請ができるのは、利用料金が発生したときに支払いについて責任を持てる教職員に限られます．学生で利用したい人は適切な立場の人（指導教員など）にご相談下さい．
 - 申請をするとあなたの UTokyo Account に紐付いた，本サービス用の[**サブスクリプション**](/research_computing/utokyo_azure/faq/subscription)が割り当てられます．


### PR DESCRIPTION
- 期限を知らずに申請してくる人が一定数いるので、現状は５年で終わるサービスであることを UTokyo Azure のトップページに追記

他
- 英版各ページからの学内限定ページへのリンクが日版ページを向いていたので、英版ページに修正
- FAQの料金計算方法の詳細説明先は申請ページになっているが、その申請ページには学内限定ページを見てとしか書いてなくて無駄に飛ばされるので、FAQの詳細説明先を直接学内限定ページに向くよう変更