### PR TITLE
Fix multiple classes in `<img>` are concatenated with commas

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -14,6 +14,7 @@ import collectHtmlImages from "./src/lib/CollectHtmlImagesPlugin.js";
 import copyAsset from "./src/lib/CopyAssetIntegration.js";
 import assetFileNames from "./src/lib/AssetFileNames.js";
 import rehypeRaw from "rehype-raw";
+import remarkImageClasslist from "./src/lib/remark-image-classlist.js";
 
 // https://astro.build/config
 export default defineConfig({
@@ -51,6 +52,7 @@ export default defineConfig({
           allowNoPosition: true,
         },
       ],
+      remarkImageClasslist,
     ],
     remarkRehype: {
       footnoteLabelProperties: { className: ["visually-hidden"] },

--- a/src/lib/remark-image-classlist.ts
+++ b/src/lib/remark-image-classlist.ts
@@ -1,0 +1,22 @@
+import { visit } from "unist-util-visit";
+import type { Root } from "mdast";
+import type { Plugin } from "unified";
+
+// Fixes the issue that multiple classes are concatenated with commas by Astro
+// NOTE: This plugin must be used at the end of the plugins list
+const remarkImageClasslist: Plugin<[], Root> = () => {
+  return (tree) => {
+    visit(tree, "image", (node) => {
+      if (node.type === "image") {
+        node.data = node.data || {};
+        const { className, ...rest } = node.data.hProperties || {};
+        node.data.hProperties = {
+          ...rest,
+          "class:list": className,
+        };
+      }
+    });
+  };
+};
+
+export default remarkImageClasslist;


### PR DESCRIPTION
- #1217 を代替するPRです
- よくわからないがこれで綺麗に治ります
  - おそらく[このへん](https://github.com/withastro/astro/blob/627aec3f04de424ec144cefac4a5a3b70d9ba0fb/packages/astro/src/runtime/server/render/util.ts#L97-L100)と関係があります（ちゃんと読んでない）
- Astro v5（別ブランチで作業中）でも動くことを確認しています