### PR TITLE
fix link to iMovie usage page

### DIFF
--- a/src/pages/articles/create_share_movie/index.md
+++ b/src/pages/articles/create_share_movie/index.md
@@ -27,7 +27,7 @@ title: 動画を作成・共有する
 * iMovie（Mac）
   * Mac に標準で備わっている動画編集ソフトウェアです．
   * 初心者でも編集しやすいため，凝った編集をしない場合はこちらのソフトウェアがおすすめです
-  * [使い方（外部サイト）](https://www.pasoble.jp/windows/10/douga-hensyuu.html)
+  * [使い方（外部サイト）](https://www.pc-koubou.jp/magazine/76741)
 * Photo（Windows）
   * Windows に標準で備わっている動画編集ソフトウェアです（Photo という名前ですが動画も編集できます）．
   * [使い方（外部サイト）](https://www.pasoble.jp/windows/10/douga-hensyuu.html)

--- a/src/pages/articles/create_share_movie/index.md
+++ b/src/pages/articles/create_share_movie/index.md
@@ -26,8 +26,11 @@ title: 動画を作成・共有する
   * [使い方（外部サイト）](https://www.aiseesoft.jp/tutorials/how-to-use-losslesscut.html)
 * iMovie（Mac）
   * Mac に標準で備わっている動画編集ソフトウェアです．
-  * 初心者でも編集しやすいため，凝った編集をしない場合はこちらのソフトウェアがおすすめです
-  * [使い方（外部サイト）](https://www.pc-koubou.jp/magazine/76741)
+  * 初心者でも編集しやすいため，凝った編集をしない場合はこちらのソフトウェアがおすすめです．
+  * [使い方（外部サイト: パソコン工房 NEXMAG）](https://www.pc-koubou.jp/magazine/76741)
+    * 基本的な操作を解説したページです．
+  * [使い方（外部サイト: Apple サポート）](https://support.apple.com/ja-jp/guide/imovie/welcome/mac)
+    * Apple社公式のユーザガイドです．詳細な使い方を知りたい場合に有用です．
 * Photo（Windows）
   * Windows に標準で備わっている動画編集ソフトウェアです（Photo という名前ですが動画も編集できます）．
   * [使い方（外部サイト）](https://www.pasoble.jp/windows/10/douga-hensyuu.html)


### PR DESCRIPTION
- 変更したページ
  - [変更前（現状）](https://utelecon.adm.u-tokyo.ac.jp/articles/create_share_movie/)
  - [変更後](https://deploy-preview-1384--utelecon.netlify.app/articles/create_share_movie/)
- ~~[Apple公式のユーザガイド](https://support.apple.com/ja-jp/guide/imovie/welcome/mac)に差し替えることも検討したのですが、初めて使うユーザにとってわかりやすい内容だとは思えないので、パソコン工房さんのページ（露骨な広告などが含まれない）を選択しました~~