### PR TITLE
英語ページの動線改善

### DIFF
--- a/src/layouts/Header/index.astro
+++ b/src/layouts/Header/index.astro
@@ -17,13 +17,14 @@ const localization = {
     top: "TOP",
     about: "About",
     theOtherLang: "English",
+    theOtherLangNavigation: "English version is here",
   },
   en: {
-    title:
-      "The Portal Site of Information Systems @ UTokyo",
+    title: "The Portal Site of Information Systems @ UTokyo",
     top: "TOP",
     about: "About",
     theOtherLang: "日本語",
+    theOtherLangNavigation: "日本語はここから",
   },
 }[lang];
 
@@ -68,14 +69,20 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
   </div>
   <div class="hamburger-contents">
     <div class="links">
+      <a id="changeLangLink" href={theOtherLangUrl}
+        >{localization.theOtherLang}</a
+      >
       <Search />
       <div>
         <a href={urls.top}>{localization.top}</a> | <a href={urls.about}
           >{localization.about}</a
-        > | <a href={theOtherLangUrl}>{localization.theOtherLang}</a>
+        >
       </div>
     </div>
     <Navigation lang={lang} />
+  </div>
+  <div class="change-lang-mobile">
+    <a href={theOtherLangUrl}>{localization.theOtherLangNavigation}</a>
   </div>
 </header>
 
@@ -111,6 +118,9 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
   .hamburger-contents {
     display: contents;
   }
+  .change-lang-mobile {
+    display: none;
+  }
   @media (max-width: $header-hamburger-breakpoint) {
     header.header {
       display: flex;
@@ -140,6 +150,9 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
         overflow-y: scroll;
       }
     }
+    .change-lang-mobile {
+      display: block;
+    }
   }
 
   @mixin background {
@@ -165,6 +178,9 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
     }
     .hamburger-contents {
       background-color: $header-nav-bg-color;
+    }
+    .change-lang-mobile {
+      background-color: $header-nav-bg-color-dark;
     }
   }
 
@@ -248,6 +264,29 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
       flex-direction: column;
       row-gap: 1em;
       padding: 1em;
+    }
+  }
+
+  .change-lang-mobile {
+    text-align: center;
+    color: white;
+    a {
+      display: inline-block;
+      width: 100%;
+      ::after {
+        content: "double_arrow";
+        font-family: "Material Icons";
+      }
+    }
+  }
+  #changeLangLink {
+    display: inline-block;
+    font-weight: bold;
+    border: 1px solid white;
+    padding: 0.2rem 0.5rem;
+    margin: 0 1em;
+    :hover {
+      text-decoration: none;
     }
   }
 

--- a/src/layouts/Header/index.astro
+++ b/src/layouts/Header/index.astro
@@ -81,7 +81,7 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
     </div>
     <Navigation lang={lang} />
   </div>
-  <div class="change-lang-mobile">
+  <div id="changeLangNavigation">
     <a href={theOtherLangUrl}>{localization.theOtherLangNavigation}</a>
   </div>
 </header>
@@ -93,6 +93,24 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
   button.addEventListener("click", () => {
     header.classList.toggle("header--hamburger-open");
   });
+
+  // ブラウザの言語設定とページの言語が一致する場合は言語ナビゲーションを表示しない
+  const browserLang = (
+    (navigator.languages && navigator.languages[0]) ||
+    navigator.language ||
+    navigator.userLanguage
+  )
+    .toLowerCase()
+    .substring(0, 2);
+
+  const pageLang = (document.documentElement.lang || "")
+    .toLowerCase()
+    .substring(0, 2);
+
+  if (browserLang == pageLang) {
+    const changeLangNavigation = document.getElementById("changeLangNavigation");
+    changeLangNavigation.style.display = "none";
+  }
 </script>
 
 <style lang="scss">
@@ -118,7 +136,7 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
   .hamburger-contents {
     display: contents;
   }
-  .change-lang-mobile {
+  #changeLangNavigation {
     display: none;
   }
   @media (max-width: $header-hamburger-breakpoint) {
@@ -150,7 +168,7 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
         overflow-y: scroll;
       }
     }
-    .change-lang-mobile {
+    #changeLangNavigation {
       display: block;
     }
   }
@@ -179,7 +197,7 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
     .hamburger-contents {
       background-color: $header-nav-bg-color;
     }
-    .change-lang-mobile {
+    #changeLangNavigation {
       background-color: $header-nav-bg-color-dark;
     }
   }
@@ -267,7 +285,7 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
     }
   }
 
-  .change-lang-mobile {
+  #changeLangNavigation {
     text-align: center;
     color: white;
     a {

--- a/src/layouts/Header/index.astro
+++ b/src/layouts/Header/index.astro
@@ -107,7 +107,7 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
     .toLowerCase()
     .substring(0, 2);
 
-  if (browserLang == pageLang) {
+  if (browserLang == pageLang || (pageLang == "en" && browserLang != "ja")) {
     const changeLangNavigation = document.getElementById("changeLangNavigation");
     changeLangNavigation.style.display = "none";
   }
@@ -197,9 +197,6 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
     .hamburger-contents {
       background-color: $header-nav-bg-color;
     }
-    #changeLangNavigation {
-      background-color: $header-nav-bg-color-dark;
-    }
   }
 
   .hamburger-button {
@@ -287,25 +284,26 @@ const theOtherLangUrl = canonicalUrl.pathname.startsWith("/en/")
 
   #changeLangNavigation {
     text-align: center;
+    background-color: $header-nav-bg-color;
     color: white;
     a {
       display: inline-block;
       width: 100%;
-      ::after {
-        content: "double_arrow";
+      &::after {
+        content: "keyboard_double_arrow_right";
         font-family: "Material Icons";
+        font-weight: 200;
+        vertical-align: middle;
       }
     }
   }
   #changeLangLink {
     display: inline-block;
+    background-color: $header-nav-bg-color;
     font-weight: bold;
     border: 1px solid white;
-    padding: 0.2rem 0.5rem;
+    padding: 0.25rem 0.5rem;
     margin: 0 1em;
-    :hover {
-      text-decoration: none;
-    }
   }
 
   @media print {


### PR DESCRIPTION
英語ページへの動線を改善します。
- ヘッダーの言語切り替えリンクを目立つ位置に変更、デザインを強化しました。
- モバイル環境において、ブラウザの言語設定とページの言語一致しない場合に、言語切り替え用のナビゲーションをヘッダーの下に表示するようにしました。
  - ただし、英語ページから日本語ページへの切り替えナビゲーションは、日本語ユーザーにのみ表示されます。