### PR TITLE
Add ECCS and research computing sections to sitemap

### DIFF
--- a/src/data/sitemapSections.ts
+++ b/src/data/sitemapSections.ts
@@ -77,6 +77,16 @@ export const sitemapSectionsJa: SitemapSection[] = [
     name: "UTokyo VPN",
   },
   {
+    patterns: [/^\/eccs($|\/)/],
+    depth: 3,
+    name: "ECCS端末",
+  },
+  {
+    patterns: [/^\/research_computing($|\/)/],
+    depth: 3,
+    name: "全学向け高速計算機・データ活用基盤",
+  },
+  {
     patterns: [/^\/online($|\/)/, /^\/articles\//],
     depth: 2,
     name: "オンラインを活用するために",
@@ -179,6 +189,16 @@ export const sitemapSectionsEn: SitemapSection[] = [
     patterns: [/^\/en\/utokyo_vpn($|\/)/],
     depth: 3,
     name: "UTokyo VPN",
+  },
+  {
+    patterns: [/^\/en\/eccs($|\/)/],
+    depth: 3,
+    name: "ECCS Terminals",
+  },
+  {
+    patterns: [/^\/en\/research_computing($|\/)/],
+    depth: 3,
+    name: "High-performance computing and data utilization platform",
   },
   {
     patterns: [/^\/en\/online($|\/)/, /^\/articles\//],

--- a/src/data/sitemapSections.ts
+++ b/src/data/sitemapSections.ts
@@ -79,7 +79,7 @@ export const sitemapSectionsJa: SitemapSection[] = [
   {
     patterns: [/^\/eccs($|\/)/],
     depth: 3,
-    name: "ECCS端末",
+    name: "教育用計算機システム（ECCS）",
   },
   {
     patterns: [/^\/research_computing($|\/)/],
@@ -193,7 +193,7 @@ export const sitemapSectionsEn: SitemapSection[] = [
   {
     patterns: [/^\/en\/eccs($|\/)/],
     depth: 3,
-    name: "ECCS Terminals",
+    name: "Educational Campus-Wide Computing System (ECCS) Terminals",
   },
   {
     patterns: [/^\/en\/research_computing($|\/)/],


### PR DESCRIPTION
サイトマップの「その他」が大変なことになっているので，ECCS端末と全学向け高速計算機・データ活用基盤のセクションを追加しました．なお，順番については現在進行中の議論がありますので，そちらは議論がまとまり次第別途整理していただければと思います．