### PR TITLE
Fix trigger preview

### DIFF
--- a/.github/workflows/netlify.yml
+++ b/.github/workflows/netlify.yml
@@ -94,7 +94,6 @@ jobs:
         uses: nwtgck/actions-netlify@v3.0
         with:
           publish-dir: dist
-          production-branch: master
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Preview for #${{ needs.pr_number.outputs.pr_number }}"
           enable-pull-request-comment: true


### PR DESCRIPTION
問題のWarnは以下のようなものです．

> Only production deployment was conducted. The alias deploy-preview-1593 was ignored.

これは以下の行で出ています．
https://github.com/nwtgck/actions-netlify/blob/f242d4c9f946f94d2ed8413888eaf35e1f7e848d/src/main.ts#L110-L112

その条件は`productionDeploy && alias !== undefined`がtrueであることです．すなわち，`productionDeploy`がtrueになっていますので，これを`false`にする必要があります．

`productionDeploy`は以下の行で判定されます．
https://github.com/nwtgck/actions-netlify/blob/f242d4c9f946f94d2ed8413888eaf35e1f7e848d/src/main.ts#L89-L92

`productionDeploy`が`true`になるためには，

- productionBranchが定義されており，かつcontext.refが`refs/heads/${productionBranch}`である
- productionDeployが"true"である

のいずれかを満たす必要があります．後者は指定されておらず，デフォルトはfalseであることから，前者がtrueになっていると予想できます．

なお，issue_comment triggerのリファレンスによれば，refは"Default branch"になるとされているので，context.refの条件も満たすと思われ，前者が原因である可能性は高いです．
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#issue_comment

以上から，「preductionBranchを定義しない」ことで，productionDeployをfalseにし，aliasを使ってデプロイさせることができると考えられます．