### PR TITLE
20251212-en_UTokyoWifi_SecondDevice

### DIFF
--- a/src/pages/en/utokyo_wifi/_IssueAccount.mdx
+++ b/src/pages/en/utokyo_wifi/_IssueAccount.mdx
@@ -1,3 +1,3 @@
 For first-time access or an account reissue, please go back to the main page of the UTokyo Wi-Fi and follow **Step 2** in “[Steps to start using the service](/en/utokyo_wifi/#initial-setup)” to issue an account.
 
-If you already have a valid UTokyo Wi-Fi account, there is no need to have an account issued again. One UTokyo Wi-Fi account can be used for two or more devices.
+Please note that you can use your issued UTokyo Wi-Fi account to connect to UTokyo Wi-Fi on multiple devices.


### PR DESCRIPTION
1つのUTokyo Wi-fiアカウントで複数端末の接続が可能であるという旨が明確に表されるよう文章を変更しました。
修正箇所の英語文章は、src/pages/en/utokyo_wifi/index.mdx と同じ文章です。
 （日本語修正 --> [#1742] 20251128_UTokyoWifi_SecondDevice）
修正ファイル: src/pages/en/utokyo_wifi/_IssueAccount.mdx