### PR TITLE
Fix redirect path separator while building on Windows

### DIFF
--- a/integrations/redirect.ts
+++ b/integrations/redirect.ts
@@ -30,10 +30,9 @@ export default function redirect(): AstroIntegration {
           const { redirect_to, redirect_from } = file.data;
           const here =
             "/" +
-            relative(pages, file.path).replace(
-              /(?:index)?\.(?:md|mdx|markdown|astro)$/,
-              "",
-            );
+            relative(pages, file.path)
+              .replace(/\\/g, "/")
+              .replace(/(?:index)?\.(?:md|mdx|markdown|astro)$/, "");
           if (typeof redirect_to === "string") {
             return { from: here, to: redirect_to };
           }


### PR DESCRIPTION
`integrations/redirect.ts` において、リダイレクト元のパス表記がWindows式 (パス区切り文字 `\`) の際にビルドが失敗する問題を修正しました。