### PR TITLE
Remove baseUrl from tsconfig

### DIFF
--- a/src/components/pages/Events.astro
+++ b/src/components/pages/Events.astro
@@ -2,7 +2,7 @@
 import { getCollection } from "astro:content";
 import If from "@components/utils/If.astro";
 import type { Lang } from "@components/types";
-import { getLocaleDateString } from "src/util";
+import { getLocaleDateString } from "../../util";
 
 interface EventInformation {
   key: string;

--- a/src/components/pages/NewsLetter.astro
+++ b/src/components/pages/NewsLetter.astro
@@ -1,7 +1,7 @@
 ---
 import type { MarkdownInstance } from "astro";
 import type { Lang } from "@components/types";
-import { getISODateString } from "src/util";
+import { getISODateString } from "../../util";
 
 interface Frontmatter {
     title: string;

--- a/src/components/pages/Notice.astro
+++ b/src/components/pages/Notice.astro
@@ -2,7 +2,7 @@
 import { getEntry } from "astro:content";
 import Markdown from "@components/utils/Markdown.astro";
 import type { Lang } from "@components/types";
-import { getISODateString, getLocaleDateString } from "src/util";
+import { getISODateString, getLocaleDateString } from "../../util";
 
 /**
  * `Markdown`の利用例として紹介されています．

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,7 +3,7 @@ import { defineCollection } from "astro:content";
 import { z } from "astro/zod";
 import { glob } from "astro/loaders";
 import { FORMATS, NUMBERS, TOOLS, KEYWORDS } from "@components/pages/GoodPractice";
-import { getISODateString } from "src/util";
+import { getISODateString } from "./util";
 
 const emergencies = defineCollection({
   loader: glob({ pattern: "*.{md,mdx}", base: "./src/emergencies" }),

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -1,4 +1,4 @@
-@use "node_modules/normalize.css/normalize";
+@use "../../node_modules/normalize.css/normalize";
 @use "sass:meta";
 
 * {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,12 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
-    "baseUrl": ".",
     "jsx": "preserve",
     "paths": {
-      "@components/*": ["src/components/*"],
-      "@data/*": ["src/data/*"],
-      "@layouts/*": ["src/layouts/*"],
-      "@styles/*": ["src/styles/*"]
+      "@components/*": ["./src/components/*"],
+      "@data/*": ["./src/data/*"],
+      "@layouts/*": ["./src/layouts/*"],
+      "@styles/*": ["./src/styles/*"]
     }
   },
   "mdx": {


### PR DESCRIPTION
TypeScript 7 での `baseUrl` 削除を見越して現行バージョンで deprecated となったため、`tsconfig` からこの設定を削除し、パスの指定を `paths` に吸収させました。