### PR TITLE
Add dependabot PR diff-comparing workflow

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,64 @@
+name: Review Dependabot PRs
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build_base:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-base
+          path: dist/
+
+  build_pr:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - uses: actions/cache@v5
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: dist-pr
+          path: dist/
+
+  compare:
+    needs: [build_base, build_pr]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist-base
+          path: dist-base/
+      - uses: actions/download-artifact@v8
+        with:
+          name: dist-pr
+          path: dist-pr/
+      - run: diff -r dist-base/ dist-pr/

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   build_base:
     runs-on: ubuntu-latest
@@ -15,17 +19,14 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: actions/cache@v5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          cache: npm
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-artifact@v7
         with:
           name: dist-base
           path: dist/
+          include-hidden-files: true
 
   build_pr:
     runs-on: ubuntu-latest
@@ -37,21 +38,19 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: 24
-      - uses: actions/cache@v5
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-
+          cache: npm
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-artifact@v7
         with:
           name: dist-pr
           path: dist/
+          include-hidden-files: true
 
   compare:
     needs: [build_base, build_pr]
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - uses: actions/download-artifact@v8
         with:
@@ -61,4 +60,38 @@ jobs:
         with:
           name: dist-pr
           path: dist-pr/
-      - run: diff -r dist-base/ dist-pr/
+      - name: Compare
+        run: |
+          diff -r  dist-base/ dist-pr/ >diff.txt       || true
+          diff -rq dist-base/ dist-pr/ >diff-brief.txt || true
+
+          count=$(wc -l <diff-brief.txt)
+          if [ "$count" -eq 0 ]; then
+            echo 'No differences found between the base and the PR build.' >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          {
+            echo "Differences found in $count file(s)."
+            echo
+            echo '<details><summary>Changed files</summary>'
+            echo
+            echo '```'
+            head -n 100 diff-brief.txt
+            if [ "$count" -gt 100 ]; then
+              echo "... and $((count - 100)) more."
+            fi
+            echo '```'
+            echo
+            echo '</details>'
+            echo
+            echo 'Download the `diff` artifact of this run for the full output.'
+          } >>"$GITHUB_STEP_SUMMARY"
+          exit 1
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: diff
+          path: |
+            diff.txt
+            diff-brief.txt

--- a/.github/workflows/report-dependabot-review.yml
+++ b/.github/workflows/report-dependabot-review.yml
@@ -36,27 +36,58 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Read the report
-        id: report
-        if: steps.download.outcome == 'success'
-        run: |
-          pr=$(cat report/pr-number)
-          count=$(cat report/count)
-          echo "pr=$pr"       >>"$GITHUB_OUTPUT"
-          echo "count=$count" >>"$GITHUB_OUTPUT"
-          echo "PR #$pr: $count differing file(s)"
-
-      - name: Post or update the comment
-        if: steps.report.outcome == 'success' && (env.MODE == 'comment' || env.MODE == 'both')
+      # 比較まで到達していれば report/ がある。ビルドが失敗した場合は無いので、
+      # その場合も PR 番号だけは特定して、古い承認やコメントを残さないようにする。
+      - name: Resolve the pull request and the result
+        id: result
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.report.outputs.pr }}
-          COUNT: ${{ steps.report.outputs.count }}
+          PAYLOAD_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          if [ -f report/pr-number ]; then
+            pr=$(cat report/pr-number)
+            count=$(cat report/count)
+            state=compared
+          else
+            pr="$PAYLOAD_PR"
+            if [ -z "$pr" ]; then
+              pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls?state=open&head=${GITHUB_REPOSITORY%%/*}:$HEAD_BRANCH" \
+                     --jq '.[0].number // empty')
+            fi
+            count=
+            state=incomplete
+          fi
+
+          if [ -z "$pr" ]; then
+            echo 'Could not determine the pull request number. Nothing to do.'
+            state=unknown
+          fi
+
+          {
+            echo "pr=$pr"
+            echo "count=$count"
+            echo "state=$state"
+          } >>"$GITHUB_OUTPUT"
+          echo "pr=$pr count=$count state=$state"
+
+      - name: Post or update the comment
+        if: steps.result.outputs.state != 'unknown' && (env.MODE == 'comment' || env.MODE == 'both')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.result.outputs.pr }}
+          COUNT: ${{ steps.result.outputs.count }}
+          STATE: ${{ steps.result.outputs.state }}
           RUN_URL: ${{ github.event.workflow_run.html_url }}
         run: |
           marker='<!-- dependabot-diff-report -->'
 
-          if [ "$COUNT" -eq 0 ]; then
+          if [ "$STATE" != 'compared' ]; then
+            body=$(printf '%s\n%s\n\n%s\n' \
+              "$marker" \
+              'Build output comparison: **could not compare**. The build did not complete.' \
+              "See the [workflow run]($RUN_URL) for details.")
+          elif [ "$COUNT" -eq 0 ]; then
             body=$(printf '%s\n%s\n\n%s\n' \
               "$marker" \
               'Build output comparison: **no differences** between the base branch and this pull request.' \
@@ -82,10 +113,10 @@ jobs:
 
       # 差分がなければ approve する。既に自分の承認があれば何もしない (冪等)。
       - name: Approve when there is no difference
-        if: steps.report.outcome == 'success' && steps.report.outputs.count == '0' && (env.MODE == 'approve' || env.MODE == 'both')
+        if: steps.result.outputs.state == 'compared' && steps.result.outputs.count == '0' && (env.MODE == 'approve' || env.MODE == 'both')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.report.outputs.pr }}
+          PR: ${{ steps.result.outputs.pr }}
         run: |
           existing=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" --paginate \
             --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
@@ -99,18 +130,26 @@ jobs:
             -f event=APPROVE \
             -f body='The build output is identical to the base branch.'
 
-      # 差分が出たのに以前の承認が残っている場合は取り消す。
-      - name: Dismiss a stale approval when differences appear
-        if: steps.report.outcome == 'success' && steps.report.outputs.count != '0' && (env.MODE == 'approve' || env.MODE == 'both')
+      # 差分が出た場合と、比較まで到達しなかった場合は、過去の承認を取り消す。
+      # 取り消すのは Bot 自身の承認だけで、人によるレビューには触れない。
+      - name: Dismiss a stale approval
+        if: steps.result.outputs.state != 'unknown' && steps.result.outputs.count != '0' && (env.MODE == 'approve' || env.MODE == 'both')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ steps.report.outputs.pr }}
+          PR: ${{ steps.result.outputs.pr }}
+          STATE: ${{ steps.result.outputs.state }}
         run: |
+          if [ "$STATE" = 'compared' ]; then
+            reason='The build output no longer matches the base branch.'
+          else
+            reason='The build output could not be compared because the build did not complete.'
+          fi
+
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" --paginate \
             --jq '.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED") | .id' |
           while read -r id; do
             gh api -X PUT "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews/$id/dismissals" \
-              -f message='The build output no longer matches the base branch.' \
+              -f message="$reason" \
               -f event=DISMISS >/dev/null
             echo "Dismissed review $id"
           done

--- a/.github/workflows/report-dependabot-review.yml
+++ b/.github/workflows/report-dependabot-review.yml
@@ -1,0 +1,116 @@
+name: Report Dependabot Review
+
+# 権限を持つ側。workflow_run で発火するため master 側のこのファイルが使われ、
+# PR のコードは一切実行しない。したがって pull-requests: write を持たせても安全。
+
+on:
+  workflow_run:
+    workflows: [Review Dependabot PRs]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+env:
+  # 差分がなかったときの動作を切り替える。
+  #   comment  … コメントするだけ
+  #   approve  … approve するだけ
+  #   both     … 両方
+  # approve を使う場合、リポジトリ設定の
+  # "Allow GitHub Actions to create and approve pull requests" が有効である必要がある。
+  MODE: comment
+
+jobs:
+  report:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download the report
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: diff-report
+          path: report/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read the report
+        id: report
+        if: steps.download.outcome == 'success'
+        run: |
+          pr=$(cat report/pr-number)
+          count=$(cat report/count)
+          echo "pr=$pr"       >>"$GITHUB_OUTPUT"
+          echo "count=$count" >>"$GITHUB_OUTPUT"
+          echo "PR #$pr: $count differing file(s)"
+
+      - name: Post or update the comment
+        if: steps.report.outcome == 'success' && (env.MODE == 'comment' || env.MODE == 'both')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.report.outputs.pr }}
+          COUNT: ${{ steps.report.outputs.count }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          marker='<!-- dependabot-diff-report -->'
+
+          if [ "$COUNT" -eq 0 ]; then
+            body=$(printf '%s\n%s\n\n%s\n' \
+              "$marker" \
+              'Build output comparison: **no differences** between the base branch and this pull request.' \
+              "See the [workflow run]($RUN_URL) for details.")
+          else
+            body=$(printf '%s\n%s\n\n%s\n' \
+              "$marker" \
+              "Build output comparison: **$COUNT file(s) differ** between the base branch and this pull request." \
+              "Review the \`diff\` artifact of the [workflow run]($RUN_URL) before merging.")
+          fi
+
+          # 同じ marker を持つ既存コメントがあれば書き換える (毎回積み上げない)
+          id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+                 --jq "[.[] | select(.body | startswith(\"$marker\"))] | last | .id // empty")
+
+          if [ -n "$id" ]; then
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" -f body="$body" >/dev/null
+            echo "Updated comment $id"
+          else
+            gh api -X POST "repos/$GITHUB_REPOSITORY/issues/$PR/comments" -f body="$body" >/dev/null
+            echo "Created a new comment"
+          fi
+
+      # 差分がなければ approve する。既に自分の承認があれば何もしない (冪等)。
+      - name: Approve when there is no difference
+        if: steps.report.outcome == 'success' && steps.report.outputs.count == '0' && (env.MODE == 'approve' || env.MODE == 'both')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.report.outputs.pr }}
+        run: |
+          existing=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" --paginate \
+            --jq '[.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED")] | length')
+
+          if [ "$existing" -gt 0 ]; then
+            echo 'Already approved. Nothing to do.'
+            exit 0
+          fi
+
+          gh api -X POST "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" \
+            -f event=APPROVE \
+            -f body='The build output is identical to the base branch.'
+
+      # 差分が出たのに以前の承認が残っている場合は取り消す。
+      - name: Dismiss a stale approval when differences appear
+        if: steps.report.outcome == 'success' && steps.report.outputs.count != '0' && (env.MODE == 'approve' || env.MODE == 'both')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ steps.report.outputs.pr }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews" --paginate \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and .state == "APPROVED") | .id' |
+          while read -r id; do
+            gh api -X PUT "repos/$GITHUB_REPOSITORY/pulls/$PR/reviews/$id/dismissals" \
+              -f message='The build output no longer matches the base branch.' \
+              -f event=DISMISS >/dev/null
+            echo "Dismissed review $id"
+          done

--- a/.github/workflows/review-dependabot-prs.yml
+++ b/.github/workflows/review-dependabot-prs.yml
@@ -1,8 +1,14 @@
 name: Review Dependabot PRs
 
+# 権限を持たない側。PR のコードをビルドするため、read-only で動かす。
+# 結果を artifact に書き出し、PR への書き込みは report-dependabot-review.yml が行う。
+
 on:
   pull_request:
     branches: [master]
+
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -60,12 +66,19 @@ jobs:
         with:
           name: dist-pr
           path: dist-pr/
+
       - name: Compare
+        id: compare
         run: |
           diff -r  dist-base/ dist-pr/ >diff.txt       || true
           diff -rq dist-base/ dist-pr/ >diff-brief.txt || true
 
           count=$(wc -l <diff-brief.txt)
+
+          mkdir -p report
+          echo "${{ github.event.pull_request.number }}" >report/pr-number
+          echo "$count"                                  >report/count
+
           if [ "$count" -eq 0 ]; then
             echo 'No differences found between the base and the PR build.' >>"$GITHUB_STEP_SUMMARY"
             exit 0
@@ -88,6 +101,14 @@ jobs:
             echo 'Download the `diff` artifact of this run for the full output.'
           } >>"$GITHUB_STEP_SUMMARY"
           exit 1
+
+      # 差分の有無にかかわらず結果を残す。report 側がこれを読む。
+      - uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: diff-report
+          path: report/
+
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/.github/workflows/review-dependabot-prs.yml
+++ b/.github/workflows/review-dependabot-prs.yml
@@ -19,9 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      # マージ後の状態と、その計算元になった master を比較する。
+      # base.sha はイベント発生時点で固定される一方、マージ ref は別のタイミングで
+      # 再計算されるため、両者を混ぜると PR と無関係な master の変更を拾ってしまう。
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 2
+      - name: Move to the base parent of the merge commit
+        run: git checkout HEAD^1
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -40,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
Dependabot による Pull Request のレビュー (生成物の diff 比較) を自動で行う GitHub Actions workflow を追加します。

> 引き継ぎに伴い、@hyper1FU が検証と改善を行い、説明文を更新しました。
> 元の実装からの変更点と、確認したい点を以下にまとめています。

## 概要

Dependabot の PR に対して、master のビルド成果物と PR のビルド成果物を `diff` で比較する
GitHub Actions workflow を追加します。差分がなければ check passed、差分があれば check failed
となり、人間がレビューする、という運用を想定しています。

これまで各自が手元で「master と PR ブランチをそれぞれビルドして `diff -r` する」という手順を
実施していたものを、そのまま CI に載せた形です。

workflow は2本に分かれています。

### `review-dependabot-prs.yml` — ビルドと比較（書き込み権限なし）

| ジョブ | 内容 |
|---|---|
| `build_base` | マージ ref の第1親（＝マージ元の master）を checkout してビルド、`dist-base` として artifact 化 |
| `build_pr` | マージ ref（＝マージ後の状態）を checkout してビルド、`dist-pr` として artifact 化 |
| `compare` | 両方を download して `diff -r` / `diff -rq`。差分があれば exit 1 |

3ジョブとも `github.event.pull_request.user.login == 'dependabot[bot]'` のガードが付いており、
通常の PR では全ジョブが skip されます。

### `report-dependabot-review.yml` — PR への報告（書き込み権限あり）

Dependabot 起点の `pull_request` イベントでは `GITHUB_TOKEN` が read-only になり、
Secrets も渡されません。PR のコードを `npm ci` で実行する以上これは妥当な制限で、
したがってビルドする側の workflow から PR にコメントや approve はできません。

そこで比較結果を artifact に出し、`workflow_run` で発火する別 workflow が
`pull-requests: write` を持って報告を担当する構成にしました。この workflow は
master 側のファイルが使われ、PR のコードを一切実行しません。

なお `pull_request_target` は、書き込み権限を持ったまま PR のコードを実行することになるため
使用していません。

動作は環境変数で切り替えられます。

```yaml
env:
  MODE: comment   # comment / approve / both
```

現在は `comment`（結果を PR にコメントするだけ）にしてあります。

## 動作検証について

この PR は本家では一度も実行されていません（この PR 自体が Dependabot 発ではないため
全ジョブが skip されます）。そのため fork (hyper1FU/utelecon.github.io) 上で
`if` の条件を自分のアカウント名に差し替えて検証しました。

### 基本動作

3ジョブとも最後まで通ります。所要時間は約6分（2つのビルドが並列で約5分、比較が25秒〜1分半）。

**ビルドは決定的**でした。中身を変えていない PR では diff が完全に空になります。
ビルド時刻やコミットハッシュが成果物に埋め込まれる、といった問題はありません。
この仕組みの大前提が満たされていることを確認できました。

`actions/upload-artifact` は v4 以降ドット始まりのファイルをデフォルトで除外するため、
`include-hidden-files: true` を追加しています。これがないと隠しファイルが比較対象から漏れます。

### open な Dependabot PR 15件の実測

現在 open な Dependabot PR すべてについて、master に適用した場合の差分を測りました。
数字は差分のあったファイル数です。

```
@astrojs/rss      4.0.18 → 4.0.19       0
brace-expansion    5.0.5 → 5.0.9        0
devalue            5.6.4 → 5.8.1        0
fast-uri           3.1.0 → 3.1.7        0
fast-xml-builder   1.1.4 → 1.2.0        0
fast-xml-parser   5.5.11 → 5.7.1        0
immutable          5.1.5 → 5.1.9        0
js-yaml            4.1.1 → 4.3.1        0
nanoid            3.3.11 → 3.3.18       0
postcss            8.5.6 → 8.5.26       0
svgo               4.0.1 → 4.0.2        0
rollup            4.46.2 → 4.60.1     851
sharp / @astrojs/mdx / astro       ビルド失敗
vite / @astrojs/* / astro          ビルド失敗
esbuild / @astrojs/* / astro       ビルド失敗
```

**ビルドが通る12件のうち11件が差分ゼロ**でした。

### rollup で出た差分の内容

唯一差分が出た rollup について、849ファイル全件を機械的に検証しました。

```
CSS ルールの集合が一致           849 / 849 ファイル
うちルールの並び順が変わったもの  849 ファイル
CSS 以外の差が空白のみ           848 ファイル
CSS 以外に実体のある差            1 ファイル
<style> 要素数の変化 (4個 → 3個)  845 ファイル
```

rollup が変えたのは、**インライン CSS を何個の `<style>` 要素に分けるか**と、
**ルールをどの順に並べるか**だけでした。CSS のルールそのものは1バイトも変わっていません。

例外の1ファイルは `good-practice/index.html` で、差分は参照している JS のファイル名だけです
（`client.D2WMwoKK.js` → `client.SBHmtuwi.js`）。その JS 本体も差し替わっています。
Astro はファイル名に中身から計算したハッシュを含めるため、名前が変わった = 中身が変わった、
ということです。

CSS のルール順はカスケードに影響し得るため、機械的に無視してよい差分ではありません。
「差分あり → 人がレビュー」という設計自体は妥当だと考えます。

### astro を含む3件について

astro を含む3件は、比較以前にビルドが通りません。

```
Package astro@7.0.7 not satisfy the version range "5.0.0 - 5.18.1"
  at checkPackageVersion (integrations/ignore-assets/index.ts:40)
```

`integrations/ignore-assets/index.ts` の `TESTED_ASTRO_VERSION_RANGE` の上限が
現行 master の astro バージョンちょうど（5.18.1）で、astro が上がれば必ず落ちる設計です。
astro 7 で `ignore-assets` / `asset-colocation` の動作確認をして定数を更新しない限り
マージできません。

この workflow の観点では3件とも check が失敗するので、見落とすことはありません。

## サマリの出力方式について

rollup の diff は 19,218,645 バイト / 10,223 行になりました。minify 済みのため1行が
平均 1.9KB あり、当初の `head -c 60000` では全体の 0.3% しか表示できません。

`diff -rq` によるファイル名一覧と件数をサマリに出し、全文は artifact に置いて
そちらを参照させる方式に変更しています。

```
Differences found in 849 file(s).

<details><summary>Changed files</summary>
（先頭100件のファイル名。それ以上は "... and N more."）
</details>

Download the `diff` artifact of this run for the full output.
```

## 承認の状態管理について

`MODE` を `approve` または `both` にした場合、承認したあとに PR の中身が変わるケース
（Dependabot が rebase する、より新しいバージョンで差し替わる等）に備えて、
Bot 自身の承認を取り消す処理を入れてあります。取り消すのは Bot の承認だけで、
人によるレビューには触れません。

通常はブランチ保護の「新しいコミットで既存のレビューを無効化する」設定で行うところですが、
このリポジトリにはブランチ保護がないため workflow 側で行っています。

以下の遷移は fork で確認済みです。

```
差分なし                  → 承認が付く / コメント "no differences"
差分なし → 差分あり        → 承認が取り消される / "N file(s) differ"
差分なし → ビルド失敗      → 承認が取り消される / "could not compare"
ビルド失敗 → 差分なし      → 承認が付き直す
差分なしのまま再実行       → 二重承認しない
```

コメントは毎回同じものを上書きするので、PR に積み上がりません。

なお `MODE` に `approve` を含める場合、リポジトリ設定の
「Allow GitHub Actions to create and approve pull requests」を有効にする必要があります
（デフォルトは無効で、そのままでは 422 で失敗します）。

## netlify.yml とのビルド重複について

netlify.yml も PR ごとに `npm run build` を実行しているため、
Dependabot の PR 1件につき `npm run build` が3回走ることになります
（netlify / build_pr / build_base）。

netlify の成果物を再利用するには netlify.yml 側に `upload-artifact` を追加し、
この workflow を `workflow_run` で受ける構成が必要になりますが、全体が読みにくくなります。
重複は認識した上で、**独立させたほうが単純で堅い**と判断してこの構成にしています。

（`build_base`（master のビルド）については、他に実行している workflow がないため
純粋に新規の実行です。）

## 確認したい点

### 1. 比較対象をマージ後の状態に変更しました（事後報告）

元の実装は `base.sha` と `head.sha` を比較していました。`head.sha` は PR ブランチの先端で、
master にマージした状態ではありません。この PR の説明文および Slack での議論は
「マージした際のビルド成果物」と述べており、江利口さんのスクリプトも
`git merge --no-commit --no-ff` でマージ後の状態を作って比較しているため、
実装のほうを合わせました。

```yaml
# PR 側: マージ後の状態
ref: refs/pull/${{ github.event.pull_request.number }}/merge

# base 側: 同じマージコミットの第1親
ref: refs/pull/${{ github.event.pull_request.number }}/merge
fetch-depth: 2
# → git checkout HEAD^1
```

**base 側も変える必要がある**点が要注意です。`base.sha` はイベント発生時点で固定される
一方、マージ ref は GitHub が別のタイミングで再計算します。両者がズレると、
PR と無関係な master の変更を差分として拾います。fork で再現したところ、
master に1ページ追加した状態で以下のようになりました。

```
merge^1 vs merge    →  0 件   （正しい）
base.sha vs merge   →  2 件   （PR と無関係な追加ページを誤検出）
```

`merge^1` と `merge` は同じマージコミットの親子なので、定義上ズレません。
netlify.yml も `refs/pull/N/merge` を使っています。

なお、`@dependabot rebase` を先に打つ運用にすれば PR ブランチ自体が最新 master の上に
載るため、`head.sha` のままでもマージ後に近い状態を比較できます（孫さんの案）。
ただし手動コマンドを挟むことになるため、CI 側で完結する形を採りました。
この判断でよいかご確認ください。

### 2. 自動承認の条件をどうするか

現状 master にブランチ保護が掛かっておらず、承認ゼロのままマージされている PR が
大半です。つまり approve はマージの条件になっていないため、Bot が approve しても
人の作業は減りません。

その意味では、コメントで結果を伝えるだけでも目的は足りている可能性があります。
approve に意味が出るのは、ブランチ保護でレビューを必須にした上で auto-merge を使い、
人手を介さずマージまで完了させる場合です。

`MODE` の値をどうするか、ご意見をいただきたいです。

## 別件として提案したいこと

### `.node-version` の導入

リポジトリに `.node-version` / `.nvmrc` / `package.json` の `engines` はいずれも存在せず、
`node-version: 24` が netlify.yml / astro.yml / この workflow に直書きされています。

Slack で「Node v24 であることを確認（はじめはしていなくて躓いた）」という話が出ていた通り、
一元管理がないことによる実害が既に出ています。`.node-version` を導入して
`node-version-file` に統一することを別 issue として提案したいですが、
**この PR では既存に合わせて直書きのままにしています**（この PR だけ変えると浮くため）。

### `web_development` ラベルの自動付与

`.github/dependabot.yml` を追加すれば実現できます。これは #2030 とは独立しているので、
別 PR として出すのがよいと考えています。

### astro のバージョンゲート

`TESTED_ASTRO_VERSION_RANGE` に引っかかる3件は、astro 7 での動作確認が必要です。
別 issue として切るのがよさそうです。
