### PR TITLE
One driveの共有に関しての有効期限の変更（英語版）

### DIFF
--- a/src/pages/en/microsoft/onedrive/share.mdx
+++ b/src/pages/en/microsoft/onedrive/share.mdx
@@ -36,7 +36,9 @@ You can choose the range of users to be shared with from the following three typ
 		- A shared link that requires a password and a shared link that does not require a password can exist at the same time. For example, even if you create a new shared link that requires a password while a shared link that does not require a password already exists, the latter remains valid.
 - **People in The University of Tokyo**
 	- Only users who are signed in to Microsoft with their UTokyo Account can access the file via this link.
-	- You cannot set an expiration date or password.
+	- You can set an expiration date.
+		- Setting an expiration date is optional.
+	- You cannot set a password.
 - **People you choose**
 	- Only the people you specify can access the file via this link.
 	- You can specify the people to share with by either of the following methods.
@@ -45,7 +47,9 @@ You can choose the range of users to be shared with from the following three typ
 		- ~~Specify an **email address**: If you specify the email address of the person you want to share with or an external Microsoft account, a one-time passcode will be sent to that email address when that person accesses the link, and they will be asked to enter the passcode on the confirmation screen.~~  
 		**As of July 14, 2026, this method is no longer available on the University of Tokyo's OneDrive. Please consider alternative methods for now.**
 	- You can choose multiple people. You can also create multiple shared links with different recipients.
-	- You cannot set an expiration date or password.
+	- You can set an expiration date.
+		- Setting an expiration date is optional.
+	- You cannot set a password.
 
 #### Types of Access Rights
 {:#access-level}


### PR DESCRIPTION
・変更箇所：
Sharing Files and Folders / Types of Shared Links That Can Be Created / Range of Users / People in The University of Tokyo & People you choose ・変更内容
有効期限を設定することはできない
→有効期限を設定することができる（必須ではない）