### PR TITLE
/en/utokyo_wifi/ 以下各端末ページの「AY2024」お知らせボックス削除・TroubleConnect修正

### DIFF
--- a/src/pages/en/utokyo_wifi/_Mfa100.mdx
+++ b/src/pages/en/utokyo_wifi/_Mfa100.mdx
@@ -1,3 +1,0 @@
-<div class="box">
-  If you plan to issue a UTokyo Wi-Fi account and use UTokyo Wi-Fi or eduroam after March 1, 2024, please refer to “[UTokyo Wi-Fi Account Usage in AY2024](/en/notice/2024/02-wifi/)”.
-</div>

--- a/src/pages/en/utokyo_wifi/_TroubleConnect.mdx
+++ b/src/pages/en/utokyo_wifi/_TroubleConnect.mdx
@@ -1,12 +1,2 @@
-- Intermittent connection happens when the signal is weak. Try changing your location and then attempt to connect again.
-- Enter the user ID for the UTokyo Wi-Fi without skipping the `u` at the beginning and `@wifi.u-tokyo.ac.jp` at the end.
-- Make sure you enter all the symbols contained in the password correctly. Try to enter it by copying and pasting it from the notification email. When you copy and paste from the notification email, avoid adding a space before the password.
-- If you do not know your user ID or password, please go back to [the main page of UTokyo Wi-Fi](/en/utokyo_wifi/) and follow **Step 2** in “Steps to start using the service” to reissue your account.
-- If you have applied for an account issue more than once, all except the last application will be invalid. When connecting, only the account displayed in [UTokyo Wi-Fi Account Menu](https://acm.wifi.adm.u-tokyo.ac.jp/secure/user_applies/index/1/) is valid.
-- Errors may occur when the software on your device is not updated. Please update the OS and then try from **Step 2** again.
-
-- If **Step 4** doesn’t work, retry **Step 3** and restart your device, and then try **Step 4** once more.
-
-If the issue is still not solved, please consult the [Technical Support Desk](/en/support/)
-
-However, if you find yourself in a situation where you are consistently (or frequently) unable to connect only at a specific location, you can also contact the person in charge of managing the facility. For contact information, please check the "[Departmental Contact for UTokyo Wi-Fi](https://univtokyo.sharepoint.com/sites/utokyoaccount/SitePages/utokyo_wifi_department_contact.aspx)" page (UTokyo Account sign-in required).
+If you experience any problems when using UTokyo Wi-Fi, please refer to the following page. It also provides detailed information on how to make inquiries.
+<b class="box center">[UTokyo Wi-Fi Troubleshooting](/en/utokyo_wifi/trouble_shooting/)</b>

--- a/src/pages/en/utokyo_wifi/_TroubleConnect.mdx
+++ b/src/pages/en/utokyo_wifi/_TroubleConnect.mdx
@@ -1,2 +1,2 @@
 If you experience any problems when using UTokyo Wi-Fi, please refer to the following page. It also provides detailed information on how to make inquiries.
-<b class="box center">[UTokyo Wi-Fi Troubleshooting](/en/utokyo_wifi/trouble_shooting/)</b>
+<b class="box center">[Troubleshooting UTokyo Wi-Fi](/en/utokyo_wifi/trouble_shooting/)</b>

--- a/src/pages/en/utokyo_wifi/android.mdx
+++ b/src/pages/en/utokyo_wifi/android.mdx
@@ -11,8 +11,6 @@ import TroubleConnect from "./_TroubleConnect.mdx"
 
 import Mfa100 from "./_Mfa100.mdx";
 
-<Mfa100 />
-
 <Intro kindOfTerminal="Android devices" confirmedTerminal="(Android 13 with Pixel 6a)"/>
 
 ## Preparation: Apply for the UTokyo Wi-Fi account

--- a/src/pages/en/utokyo_wifi/android.mdx
+++ b/src/pages/en/utokyo_wifi/android.mdx
@@ -54,7 +54,7 @@ The necessary Wi-Fi setting information will be displayed after you select the S
 #### Supplement
 {:#create-profile-notes}
 * If you cannot select “Use the system certificate” in the “CA certificate”, or it does not work even if you selected it, try selecting “Trust on the first use” 
-* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “ID” and “Password”. Note that they are not the regular ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**Preparation**” step or the screen of the completed application.
+* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “ID” and “Password”. Note that they are not the regular ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**[Preparation](#issue-account)**” step or the screen of the completed application.
 * If there are any setting items other than mentioned above, please configure them as needed. If you have no particular preferences, you can leave the default settings.
 
 ## Troubleshooting guide

--- a/src/pages/en/utokyo_wifi/android.mdx
+++ b/src/pages/en/utokyo_wifi/android.mdx
@@ -8,9 +8,6 @@ import IssueAccount from "./_IssueAccount.mdx"
 import SelectSsid from "./_SelectSsid.astro"
 import DeleteProfile from "./_DeleteProfile.astro"
 import TroubleConnect from "./_TroubleConnect.mdx"
-
-import Mfa100 from "./_Mfa100.mdx";
-
 <Intro kindOfTerminal="Android devices" confirmedTerminal="(Android 13 with Pixel 6a)"/>
 
 ## Preparation: Apply for the UTokyo Wi-Fi account

--- a/src/pages/en/utokyo_wifi/android.mdx
+++ b/src/pages/en/utokyo_wifi/android.mdx
@@ -8,6 +8,7 @@ import IssueAccount from "./_IssueAccount.mdx"
 import SelectSsid from "./_SelectSsid.astro"
 import DeleteProfile from "./_DeleteProfile.astro"
 import TroubleConnect from "./_TroubleConnect.mdx"
+
 <Intro kindOfTerminal="Android devices" confirmedTerminal="(Android 13 with Pixel 6a)"/>
 
 ## Preparation: Apply for the UTokyo Wi-Fi account

--- a/src/pages/en/utokyo_wifi/android.mdx
+++ b/src/pages/en/utokyo_wifi/android.mdx
@@ -55,7 +55,7 @@ The necessary Wi-Fi setting information will be displayed after you select the S
 #### Supplement
 {:#create-profile-notes}
 * If you cannot select “Use the system certificate” in the “CA certificate”, or it does not work even if you selected it, try selecting “Trust on the first use” 
-* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “ID” and “Password”. Note that they are not the regular ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**[Preparation](#issue-account)**” step or the screen of the completed application.
+* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “ID” and “Password”. Note that they are not the 10-digit Common ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**[Preparation](#issue-account)**” step or the screen of the completed application.
 * If there are any setting items other than mentioned above, please configure them as needed. If you have no particular preferences, you can leave the default settings.
 
 ## Troubleshooting guide

--- a/src/pages/en/utokyo_wifi/ios.mdx
+++ b/src/pages/en/utokyo_wifi/ios.mdx
@@ -11,8 +11,6 @@ import TroubleConnect from "./_TroubleConnect.mdx"
 
 import Mfa100 from "./_Mfa100.mdx";
 
-<Mfa100 />
-
 <Intro kindOfTerminal="iPhones and iPads" confirmedTerminal="(iPhoneSE (2nd generation) with iOS 16.5)"/>
 
 ## Preparation: Apply for the UTokyo Wi-Fi account

--- a/src/pages/en/utokyo_wifi/ios.mdx
+++ b/src/pages/en/utokyo_wifi/ios.mdx
@@ -8,9 +8,6 @@ import IssueAccount from "./_IssueAccount.mdx"
 import SelectSsid from "./_SelectSsid.astro"
 import DeleteProfile from "./_DeleteProfile.astro"
 import TroubleConnect from "./_TroubleConnect.mdx"
-
-import Mfa100 from "./_Mfa100.mdx";
-
 <Intro kindOfTerminal="iPhones and iPads" confirmedTerminal="(iPhoneSE (2nd generation) with iOS 16.5)"/>
 
 ## Preparation: Apply for the UTokyo Wi-Fi account

--- a/src/pages/en/utokyo_wifi/ios.mdx
+++ b/src/pages/en/utokyo_wifi/ios.mdx
@@ -1,13 +1,14 @@
 ---
 title: Using UTokyo Wi-Fi on iPhone and iPad
 breadcrumb:
-  title: iPhoneやiPadで利用する
+  title: Using UTokyo Wi-Fi on iPhone and iPad
 ---
 import Intro from "./_Intro.astro"
 import IssueAccount from "./_IssueAccount.mdx"
 import SelectSsid from "./_SelectSsid.astro"
 import DeleteProfile from "./_DeleteProfile.astro"
 import TroubleConnect from "./_TroubleConnect.mdx"
+
 <Intro kindOfTerminal="iPhones and iPads" confirmedTerminal="(iPhoneSE (2nd generation) with iOS 16.5)"/>
 
 ## Preparation: Apply for the UTokyo Wi-Fi account
@@ -45,7 +46,7 @@ The necessary Wi-Fi setting information will be displayed after you select the S
 
 #### Supplement
 {:#create-profile-notes}
-* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “User-name” and “Password”. Note that they are not the regular ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**Preparation**” step or the screen of the completed application.
+* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “User-name” and “Password”. Note that they are not the 10-digit Common ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**[Preparation](#issue-account)**” step or the screen of the completed application.
 * If there are any setting items other than mentioned above, please configure them as needed. If you have no particular preferences, you can leave the default settings.
 * During the connecting operation, a screen asking if you trust the certificate may appear. To verify whether the certificate is correct, compare the "server fingerprint" of the displayed certificate with the fingerprint listed in "[Connect Configuration](/en/utokyo_wifi/#connect-configuration)". If they match, trust the certificate.
     * In addition, there are two types of fingerprints (SHA-1 and SHA-256) listed on [Connect Configuration](/en/utokyo_wifi/#connect-configuration);matching one type will suffice

--- a/src/pages/en/utokyo_wifi/windows.mdx
+++ b/src/pages/en/utokyo_wifi/windows.mdx
@@ -8,9 +8,6 @@ import IssueAccount from "./_IssueAccount.mdx"
 import SelectSsid from "./_SelectSsid.astro"
 import DeleteProfile from "./_DeleteProfile.astro"
 import TroubleConnect from "./_TroubleConnect.mdx"
-
-import Mfa100 from "./_Mfa100.mdx";
-
 <Intro kindOfTerminal="terminal of Windows" confirmedTerminal=""/>
 
 ## Preparation: Apply for a UTokyo Wi-Fi account

--- a/src/pages/en/utokyo_wifi/windows.mdx
+++ b/src/pages/en/utokyo_wifi/windows.mdx
@@ -50,7 +50,7 @@ The screen of the Wi-Fi settings will be displayed. To enter the required settin
 
 #### Supplement
 {:#create-profile-notes}
-* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “User name” and “Password”. Note that they are not the regular ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**Preparation**” step or the screen of the completed application.
+* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “User name” and “Password”. Note that they are not the regular ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**[Preparation](#issue-account)**” step or the screen of the completed application.
 * If there are any setting items other than mentioned above, please configure them as needed. If you have no particular preferences, you can leave the default settings.
 * During the connecting operation, a screen asking if you trust the certificate may appear. To verify whether the certificate is correct, compare the "server fingerprint" of the displayed certificate with the fingerprint listed in “[Connect Configuration](../#connect-configuration)”. If they match, trust the certificate.
     * In addition, there are two types of fingerprints (SHA-1 and SHA-256) listed on [Connect Configuration](../#connect-configuration); matching one type will suffice

--- a/src/pages/en/utokyo_wifi/windows.mdx
+++ b/src/pages/en/utokyo_wifi/windows.mdx
@@ -8,6 +8,7 @@ import IssueAccount from "./_IssueAccount.mdx"
 import SelectSsid from "./_SelectSsid.astro"
 import DeleteProfile from "./_DeleteProfile.astro"
 import TroubleConnect from "./_TroubleConnect.mdx"
+
 <Intro kindOfTerminal="terminal of Windows" confirmedTerminal=""/>
 
 ## Preparation: Apply for a UTokyo Wi-Fi account

--- a/src/pages/en/utokyo_wifi/windows.mdx
+++ b/src/pages/en/utokyo_wifi/windows.mdx
@@ -50,7 +50,7 @@ The screen of the Wi-Fi settings will be displayed. To enter the required settin
 
 #### Supplement
 {:#create-profile-notes}
-* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “User name” and “Password”. Note that they are not the regular ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**[Preparation](#issue-account)**” step or the screen of the completed application.
+* Enter the user ID and password for the UTokyo Wi-Fi account into the fields of “User name” and “Password”. Note that they are not the 10-digit Common ID and password for the UTokyo Account. You can check the user ID and password in the notification email described in the ”**[Preparation](#issue-account)**” step or the screen of the completed application.
 * If there are any setting items other than mentioned above, please configure them as needed. If you have no particular preferences, you can leave the default settings.
 * During the connecting operation, a screen asking if you trust the certificate may appear. To verify whether the certificate is correct, compare the "server fingerprint" of the displayed certificate with the fingerprint listed in “[Connect Configuration](../#connect-configuration)”. If they match, trust the certificate.
     * In addition, there are two types of fingerprints (SHA-1 and SHA-256) listed on [Connect Configuration](../#connect-configuration); matching one type will suffice

--- a/src/pages/en/utokyo_wifi/windows.mdx
+++ b/src/pages/en/utokyo_wifi/windows.mdx
@@ -11,8 +11,6 @@ import TroubleConnect from "./_TroubleConnect.mdx"
 
 import Mfa100 from "./_Mfa100.mdx";
 
-<Mfa100 />
-
 <Intro kindOfTerminal="terminal of Windows" confirmedTerminal=""/>
 
 ## Preparation: Apply for a UTokyo Wi-Fi account


### PR DESCRIPTION
en/utokyo_wifi/以下のwindows, iOS, androidの3つのページから
<Mfa100 />
を削除しました。
「AY2024」お知らせボックスを削除するためです。